### PR TITLE
ci: skip grafana-dev image in CD Playwright tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,6 +46,8 @@ jobs:
       # - 'universal': on-prem + cloud (default)
       # - 'grafana_cloud': cloud only, hidden for on-prem users
       scopes: universal
+      # Skip the grafana-dev image in Playwright tests (image may be temporarily unavailable)
+      run-playwright-with-skip-grafana-dev-image: true
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to push.yaml:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs


### PR DESCRIPTION
## Summary

- Skip the `grafana-dev` image in CD Playwright E2E tests
- The `grafana-dev@12.4.0-21077525498` image is currently unavailable, causing [CD pipeline failures](https://github.com/grafana/grafana-cube-datasource/actions/runs/21079993077)
- E2E tests still run against stable Grafana releases (12.1.5, 12.2.3, 12.3.1)

## Test plan

- [ ] Re-run CD workflow to verify it passes with this change
- [ ] Consider removing this flag once the grafana-dev image issue is resolved upstream

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts CD workflow to avoid flaky `grafana-dev` image in Playwright tests.
> 
> - In `publish.yaml`, sets `run-playwright-with-skip-grafana-dev-image: true` to skip the `grafana-dev` image during E2E runs
> - No application code changes; only CI behavior updated for CD pipeline
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d4c5d7bd4333dafd0e4a48561c89aa7da8092d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->