### PR TITLE
chore: bump version to 3.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "3.6.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "3.6.0",
+      "version": "3.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

Bumps version from 3.7.0 to 3.7.1

## Important: Merge Strategy

**Please use a merge commit (not squash)** when merging this PR.

The tag `v3.7.1` has already been pushed and points to this exact commit. Squashing would create a new commit hash, orphaning the tag.

If the repo is configured to only allow squash merges, we'll need to delete and recreate the tag after merging.