### PR TITLE
fix(ci): specify go-version 1.24 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,4 @@ jobs:
         with:
           policy_token: ${{ env.GRAFANA_ACCESS_POLICY_TOKEN }}
           attestation: true
+          go-version: "1.24"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "3.7.2",
+      "version": "3.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

The release workflow failed because the `build-plugin` action defaults to Go 1.21, but our `go.mod` requires Go 1.24.6.

This PR:
- Adds `go-version: "1.24"` to the release workflow
- Bumps version to 3.7.3

## After merging

```bash
git checkout main && git pull
git tag v3.7.3
git push origin v3.7.3
```