### PR TITLE
docs: add cursor rule to prevent package-lock.json noise

### DIFF
--- a/.cursor/rules/dependencies.mdc
+++ b/.cursor/rules/dependencies.mdc
@@ -27,3 +27,34 @@ globs:
 "@testing-library/react": "^16.3.0"
 "react": "~18.3.1"
 ```
+
+## Package Lock File
+
+**Only commit `package-lock.json` changes when `package.json` was also modified.**
+
+- Running `npm install` can cause metadata-only changes to `package-lock.json` (like `"peer": true` flags) due to npm version differences
+- These changes are noise and should not be committed
+- Before committing, check if `package.json` was modified:
+  - If yes → include `package-lock.json` in the commit
+  - If no → restore `package-lock.json` with `git checkout package-lock.json`
+
+### Examples
+
+✅ **Correct: Adding a new dependency**
+```bash
+# package.json was modified, so commit both files
+git add package.json package-lock.json
+git commit -m "feat: add lodash dependency"
+```
+
+❌ **Incorrect: Committing lockfile noise**
+```bash
+# Only ran npm install, no package.json changes
+git add package-lock.json  # Don't do this!
+```
+
+✅ **Correct: Restoring lockfile after npm install**
+```bash
+# If package-lock.json changed but package.json didn't
+git checkout package-lock.json
+```


### PR DESCRIPTION
## Summary

- Adds guidance for Cursor agents to only commit `package-lock.json` changes when `package.json` was also modified
- Prevents metadata-only churn (like `"peer": true` flags) caused by npm version differences between local and cloud agent environments

## Context

Cloud agents run with a different npm version, which produces `package-lock.json` files without `"peer": true` metadata flags. When we pull those branches locally and run `npm install`, our npm adds those flags back, creating noisy diffs.

This rule instructs agents to check whether `package.json` was modified before committing lockfile changes.

## Test plan

- [ ] Verify the rule is picked up by cloud agents on future tasks that don't add/remove dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new `/.cursor/rules/dependencies.mdc` with guidance to improve dependency consistency and reduce lockfile churn.
> 
> - Enforces exact (pinned) versions in `package.json` (no `^` or `~`) for deterministic builds
> - Instructs to commit `package-lock.json` only when `package.json` changes; otherwise restore the lockfile to avoid metadata-only noise
> - Includes concise examples for correct/incorrect versions and commit workflows
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eeeed28b51b1899554590f5664a6c2a449f8d7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->