### PR TITLE
ci: skip grafana-dev image in CI Playwright tests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -42,6 +42,8 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      # Skip the grafana-dev image in Playwright tests (image may be temporarily unavailable)
+      run-playwright-with-skip-grafana-dev-image: true
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to publish.yaml:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs


### PR DESCRIPTION
The grafana-dev@12.4.0-21077525498 image is currently unavailable, causing CI pipeline failures. Skip the dev image testing while still running E2E tests against stable Grafana releases.

This unblocks CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines CI by avoiding flaky grafana-dev image usage in Playwright runs.
> 
> - Updates `.github/workflows/push.yaml` to set `run-playwright-with-skip-grafana-dev-image: true` in the shared `ci.yml` workflow inputs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e997b2c8651731f308564d63d5beff50f4ac7c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->