### PR TITLE
feat: make Dimensions and Measures MultiSelects responsive

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -145,7 +145,7 @@ const getStyles = (_theme: GrafanaTheme2) => {
     }),
     multiSelectContainer: css({
       width: '100%',
-      minWidth: '280px',
+      minWidth: '240px',
     }),
   };
 };


### PR DESCRIPTION
## Summary

- Use CSS Container Queries to make Dimensions and Measures MultiSelect widths respond to changes in available space
- Width now adjusts when toggling the left navigation or the options pane
- Tags wrap appropriately based on available space


https://github.com/user-attachments/assets/c31fc5e1-9fad-4bf2-af46-8786a13a9115



## Changes

- Add wrapper divs to establish container query context (`containerType: inline-size`)
- Use `100cqw` (100% of container width) with `minWidth: 280px` constraint
- Add `grow` prop to `InlineField` to allow expansion

## Test plan

- [x] Open the Query Editor in panel edit mode
- [x] Select multiple dimensions/measures to see tag wrapping behavior
- [x] Toggle the left navigation open/closed - MultiSelects should resize
- [x] Expand/collapse the options pane on the right - MultiSelects should resize
- [x] Verify minimum width is respected on very narrow layouts

## Tips for reviewer:

Review with "Hide whitespace" enabled, to get a clearer view on the diff:
<img width="150" height="343" alt="image" src="https://github.com/user-attachments/assets/97f98faf-b578-4f51-b8af-c62bafca1fb7" />

## Related

Partially fixes #24 (doesn't implement Filter-values yet - those haven't landed yet)
See that issue for full context on alternatives considered (viewport units, flex-based approaches, etc.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Query Editor layout responsiveness for field selectors.
> 
> - Wraps `MultiSelect` inputs for `Dimensions` and `Measures` in container-query contexts (`containerType: inline-size`) with full-width styling and `minWidth: 240px`
> - Adds `grow` to `InlineField` and removes fixed `width` props to allow dynamic resizing and tag wrapping
> - Introduces `useStyles2`, `css`, and `GrafanaTheme2`-based styles; no query logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f849b245f0cdc4e350d3ea05a2fc821d78ca5b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->