### PR TITLE
feat: allow adding filters even when existing ones are incomplete

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -35,9 +35,7 @@ export function QueryEditor({
     onRemoveOrder,
     onToggleOrderDirection,
     onReorderFields,
-    onAddFilter,
-    onUpdateFilter,
-    onRemoveFilter,
+    onFiltersChange,
   } = useQueryEditorHandlers(query, onChange, onRunQuery);
 
   // Map from query order to preserve user selection order (not metadata schema order)
@@ -105,9 +103,7 @@ export function QueryEditor({
         <FilterField
           filters={query.filters}
           dimensions={metadata.dimensions}
-          onAdd={onAddFilter}
-          onUpdate={onUpdateFilter}
-          onRemove={onRemoveFilter}
+          onChange={onFiltersChange}
           datasource={datasource}
         />
       </Field>

--- a/src/hooks/useQueryEditorHandlers.ts
+++ b/src/hooks/useQueryEditorHandlers.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent } from 'react';
-import { MyQuery, CubeFilter, Operator, Order, DEFAULT_ORDER } from '../types';
+import { MyQuery, CubeFilter, Order, DEFAULT_ORDER } from '../types';
 import { SelectableValue } from '@grafana/data';
 
 export function useQueryEditorHandlers(query: MyQuery, onChange: (query: MyQuery) => void, onRunQuery: () => void) {
@@ -75,35 +75,8 @@ export function useQueryEditorHandlers(query: MyQuery, onChange: (query: MyQuery
     updateQueryAndRun({ order: newOrder });
   };
 
-  const onAddFilter = (member: string, operator: Operator, values: string[]) => {
-    const newFilter: CubeFilter = {
-      member,
-      operator,
-      values,
-    };
-    const newFilters = [...(query.filters || []), newFilter];
-    updateQueryAndRun({ filters: newFilters });
-  };
-
-  const onUpdateFilter = (index: number, member: string, operator: Operator, values: string[]) => {
-    if (!query.filters || index >= query.filters.length) {
-      return;
-    }
-    const updatedFilter: CubeFilter = {
-      member,
-      operator,
-      values,
-    };
-    const newFilters = query.filters.map((filter, i) => (i === index ? updatedFilter : filter));
-    updateQueryAndRun({ filters: newFilters });
-  };
-
-  const onRemoveFilter = (index: number) => {
-    if (!query.filters) {
-      return;
-    }
-    const newFilters = query.filters.filter((_, i) => i !== index);
-    updateQueryAndRun({ filters: newFilters.length > 0 ? newFilters : undefined });
+  const onFiltersChange = (filters: CubeFilter[]) => {
+    updateQueryAndRun({ filters: filters.length > 0 ? filters : undefined });
   };
 
   return {
@@ -113,8 +86,6 @@ export function useQueryEditorHandlers(query: MyQuery, onChange: (query: MyQuery
     onRemoveOrder,
     onToggleOrderDirection,
     onReorderFields,
-    onAddFilter,
-    onUpdateFilter,
-    onRemoveFilter,
+    onFiltersChange,
   };
 }


### PR DESCRIPTION
## Summary

- Removes the `hasIncompleteFilter` check that disabled the "Add Filter" button when a previous filter had no field or values selected
- Simplifies UX by letting users add filters freely at any time
- Relies on existing `filterValidation.ts` to filter out incomplete filters before sending queries to Cube

## Test plan

- [x] Existing FilterField tests pass (8/8)
- [x] Manual verification: Add Filter button is always enabled
- [x] Manual verification: Incomplete filters don't cause Cube API errors (validation still works)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor filter API and wiring**
> 
> - Replace `FilterField` props `onAdd/onUpdate/onRemove` with unified `onChange`; maintain local `filterStates` and `syncToParent` to emit complete `CubeFilter[]`
> - Remove `hasIncompleteFilter` logic; `Add Filter` button is always enabled
> - Update `QueryEditor` to pass `onFiltersChange` from `useQueryEditorHandlers`; handlers consolidated to a single `onFiltersChange` that normalizes empty arrays to `undefined`
> - Revise `FilterField.test.tsx` to the new API and add assertions for `onChange` on remove, value selection, and field selection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a3ecd359792c67c0e19ad3e0569d9ca0769d033. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->