### PR TITLE
Add time-series panel and time-filtering dim to home

### DIFF
--- a/provisioning/dashboards/cube-datasource-poc.json
+++ b/provisioning/dashboards/cube-datasource-poc.json
@@ -103,8 +103,12 @@
             "type": "grafana-cube-datasource",
             "uid": "cube-datasource"
           },
-          "dimensions": ["orders.raw_customers_first_name"],
-          "measures": ["orders.raw_payments_total_amount"],
+          "dimensions": [
+            "orders.raw_customers_first_name"
+          ],
+          "measures": [
+            "orders.raw_payments_total_amount"
+          ],
           "refId": "A"
         }
       ],
@@ -196,8 +200,12 @@
             "type": "grafana-cube-datasource",
             "uid": "cube-datasource"
           },
-          "dimensions": ["orders.raw_payments_payment_method"],
-          "measures": ["orders.raw_payments_total_amount"],
+          "dimensions": [
+            "orders.raw_payments_payment_method"
+          ],
+          "measures": [
+            "orders.raw_payments_total_amount"
+          ],
           "refId": "A"
         }
       ],
@@ -273,13 +281,123 @@
             "type": "grafana-cube-datasource",
             "uid": "cube-datasource"
           },
-          "dimensions": ["orders.raw_customers_first_name", "orders.raw_customers_last_name"],
-          "measures": ["orders.raw_payments_total_amount", "orders.raw_payments_count"],
+          "dimensions": [
+            "orders.raw_customers_first_name",
+            "orders.raw_customers_last_name"
+          ],
+          "measures": [
+            "orders.raw_payments_total_amount",
+            "orders.raw_payments_count"
+          ],
           "refId": "A"
         }
       ],
       "title": "Orders: Amount and Count, by First Name",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-cube-datasource",
+        "uid": "cube-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-17253726931",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-cube-datasource",
+            "uid": "cube-datasource"
+          },
+          "dimensions": [
+            "orders.raw_orders_order_date"
+          ],
+          "measures": [
+            "orders.raw_payments_count_with_discount",
+            "orders.raw_payments_count"
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "Order Amount by Payment Method",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -350,9 +468,15 @@
             "type": "grafana-cube-datasource",
             "uid": "cube-datasource"
           },
+          "dimensions": [
+            "orders.raw_customers_first_name",
+            "orders.raw_customers_last_name"
+          ],
           "hide": true,
-          "dimensions": ["orders.raw_customers_first_name", "orders.raw_customers_last_name"],
-          "measures": ["orders.raw_payments_total_amount", "orders.raw_payments_count"],
+          "measures": [
+            "orders.raw_payments_total_amount",
+            "orders.raw_payments_count"
+          ],
           "refId": "A"
         },
         {
@@ -375,10 +499,37 @@
   "refresh": "",
   "schemaVersion": 41,
   "tags": [],
-  "templating": {},
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "orders.raw_orders_order_date",
+          "value": "orders.raw_orders_order_date"
+        },
+        "description": "This field will have the Dashboard Time-range applied to it as a filter",
+        "label": "Time-range filtering field",
+        "name": "cubeTimeDimension",
+        "options": [
+          {
+            "selected": true,
+            "text": "orders.raw_orders_order_date",
+            "value": "orders.raw_orders_order_date"
+          },
+          {
+            "selected": false,
+            "text": "not_a_real_date_field",
+            "value": "not_a_real_date_field"
+          }
+        ],
+        "query": "orders.raw_orders_order_date,not_a_real_date_field",
+        "type": "custom"
+      }
+    ]
+  },
   "time": {
-    "from": "now-6h",
-    "to": "now"
+    "from": "2018-02-20T13:19:26.734Z",
+    "to": "2018-04-14T08:31:36.641Z"
   },
   "timepicker": {},
   "timezone": "browser",


### PR DESCRIPTION
This updates the provisioned dashboard that is used as the homepage,
and which points to the dummy/seed development data

It adds:
- A time-series panel, and
- A time-filtering dimension (dashboard variable)

So that the time-range can be dragged and then filters all panels

Doing this work in anticipation of adding per-panel overrides to the
choice of the time-filtering dimension.
Because GrafanaLabs internal use-cases have a panel where that panel
only has a time-filtered dimension selected, but the rest of the
dashboard has none.

<img width="1760" height="986" alt="image" src="https://github.com/user-attachments/assets/48b8988d-2243-43fc-a83d-019bfe22eae4" />

Dragging the time-range selector across the panel applies the time-range filter to the whole dashboard 🎉 
<img width="933" height="886" alt="image" src="https://github.com/user-attachments/assets/9920bcd3-3015-4e8a-9d2e-4d83c371b5ba" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces dashboard-wide time filtering and a new time-series visualization to the provisioned Cube PoC dashboard.
> 
> - Adds a `timeseries` panel charting `orders.raw_payments_count_with_discount` and `orders.raw_payments_count` over `orders.raw_orders_order_date`
> - Adds `templating.list.cubeTimeDimension` custom variable to control which time dimension receives the dashboard time-range filter; sets a fixed example time range
> - Minor JSON restructuring (multi-line `dimensions`/`measures`) and small panel config adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d87bccd94f2729ad5ef541526d7d005797af9df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->