### PR TITLE
ci: configure Renovate to update Go version in workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,14 @@
         "automerge"
       ]
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["go-version:\\s*[\"']?(?<currentValue>[\\d.]+)[\"']?"],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a `customManager` to `renovate.json` that matches `go-version` strings in GitHub workflow files. This ensures that when `go.mod` is updated to a new Go version, the release workflow will also be updated to match.

**Problem:** PR #6 auto-merged a dependency update that bumped `go.mod` from Go 1.24 to Go 1.25, but the release workflow still had `go-version: "1.24"`. This caused the v3.7.5 release to fail.

**Solution:** Renovate will now detect `go-version:` patterns in workflow files and create PRs to update them alongside `go.mod` changes.

## Test plan

- [ ] Verify Renovate recognizes the new manager (check Renovate logs after merge)
- [ ] Next Go version bump should include workflow file updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures workflow `go-version` stays in sync with `go.mod` updates.
> 
> - Adds `customManagers` regex in `renovate.json` to match `go-version` in `.github/workflows/*.yml`/`*.yaml`
> - Uses `depNameTemplate: go` with `golang-version` datasource to auto-bump workflow Go versions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1b75b13e69c1203197832f3fae6f7266a057a6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->