### PR TITLE
docs: document release process and workflow rationale

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -55,3 +55,35 @@ gh api repos/OWNER/REPO/pulls/NUMBER -X PATCH -f body='...'
 ```bash
 gh pr edit NUMBER --body '...'
 ```
+
+## Release Process
+
+**Never push version tags before CI passes.**
+
+When creating a release:
+
+1. Create a version bump PR (use `npm version patch --no-git-tag-version`)
+2. Wait for CI to pass and merge the PR
+3. Only then create and push the tag on main
+
+✅ **Correct release flow:**
+```bash
+# On a branch - bump version without tag
+npm version patch --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "chore: release vX.Y.Z"
+# Create PR, wait for CI, merge
+
+# After merge - tag on main
+git checkout main && git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+❌ **Incorrect:**
+```bash
+npm version patch  # Creates tag immediately
+git push --follow-tags  # Pushes tag before CI validates
+```
+
+See the "Releasing" section in README.md for full documentation.


### PR DESCRIPTION
## Summary

Documents the release process and explains why we use a custom `release.yml` workflow.

**Changes:**
- Add "Releasing" section to README explaining the two-step release process
- Document why we use a custom `release.yml` instead of relying solely on `plugin-ci-workflows` (we want GitHub releases before publishing to prod)
- Add release process rules to `.cursor/rules/git-workflow.mdc` so Cursor follows the same workflow
- Clarify the protected branch workflow: version bump PR first, tag only after merge

**Context:** This came out of a discussion with the plugin-ci-workflows team about our custom release workflow. We've also suggested they consider creating GitHub releases on non-prod deployments in the future.

## Test plan

- [x] Documentation is accurate and matches current workflow
- [x] Cursor rules are actionable and reference README for details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds release documentation and aligns internal tooling with the process.
> 
> - **README:** New "Releasing" section detailing a two-step process (tag-triggered GitHub release via `release.yml`, separate catalog publishing via `publish.yaml`), rationale for split workflows, and exact steps for version bump PR then post-merge tagging
> - **Cursor rules:** Extend `git-workflow.mdc` with release rules (no tagging before CI, correct/incorrect flows, use `npm version --no-git-tag-version`, tag only after merge) and reference README
> - Minor clarification in "Publishing Workflow" intro wording
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 828a19d7bbe16b9af202c963260d36bef60f33e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->