### PR TITLE
Remove custom manager for Go version in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,14 +12,5 @@
       "automerge": true,
       "labels": ["automerge"]
     }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
-      "matchStrings": ["go-version:\\s*[\"']?(?<currentValue>[\\d.]+)[\"']?"],
-      "depNameTemplate": "go",
-      "datasourceTemplate": "golang-version"
-    }
   ]
 }


### PR DESCRIPTION
Removed custom manager configuration for Go version updates.

I checked to see if this had worked - following these instructions:
<img width="300" height="415" alt="Screenshot 2026-01-22 at 15 26 03" src="https://github.com/user-attachments/assets/574c2e24-503d-480e-87be-a44881f9b489" />

But it hadn't. Issue #8 showed this:
<img width="300" height="508" alt="image" src="https://github.com/user-attachments/assets/2ce3e0d6-cd8b-443a-85a5-68fc842f82d3" />

And worse, Renovate seems to have stopped completing properly for this repo:
<img width="250" height="442" alt="image" src="https://github.com/user-attachments/assets/5c356eaa-87c8-42c0-9b77-b1c8053d7e48" />

So this reverts PRs #39 and #42, in the hope that we can get Renovate running again on this repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Remove custom Renovate manager for Go versions**
> 
> - Deletes `customManagers` regex config that targeted `go-version` in GitHub Actions workflows
> - Retains existing presets, `platformAutomerge`, and non-major dependency automerge rules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 389ca7efbda2edcfc950c595d6489509415dcba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->