### PR TITLE
chore: release v3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.8.1 (2026-01-23)
+
+### Documentation
+
+- Rewrote changelog with complete version history
+
+**Full Changelog**: [v3.8.0...v3.8.1](https://github.com/grafana/grafana-cube-datasource/compare/v3.8.0...v3.8.1)
+
 ## 3.8.0 (2026-01-23)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

- Version bump to 3.8.1 to publish updated changelog to Grafana plugin marketplace

## Test plan

- No code changes, documentation only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documentation-only release.
> 
> - Bumps package version to `3.8.1` in `package.json` and `package-lock.json`
> - Rewrites `CHANGELOG.md` with complete history and adds `3.8.1` entry linking `v3.8.0...v3.8.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8aea4f615f49da85baa2c4b0004447aced539216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->