### PR TITLE
Revert "ci: skip grafana-dev image in CI Playwright tests"

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -42,8 +42,6 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      # Skip the grafana-dev image in Playwright tests (image may be temporarily unavailable)
-      run-playwright-with-skip-grafana-dev-image: true
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to publish.yaml:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs


### PR DESCRIPTION
Reverts grafana/grafana-cube-datasource#20

Reverting for now, as the Dev Grafana image seems to be working again: [This Github Action](https://github.com/grafana/grafana-cube-datasource/actions/runs/21354229080) just passed.

If it fails again in the future we can revert this revert!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores default Playwright test behavior in CI.
> 
> - Removes `run-playwright-with-skip-grafana-dev-image: true` from `.github/workflows/push.yaml`, allowing tests to run with the Grafana dev image
> - No application code changes; only CI workflow adjustment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d216fef7dee3e70d82999313e166763ae3f09e64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->