### PR TITLE
refactor: rename types for consistency with Grafana plugin conventions

### DIFF
--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import { setup } from 'testUtils';
 import { ConfigEditor } from './ConfigEditor';
-import { MyDataSourceOptions, MySecureJsonData } from '../types';
+import { CubeDataSourceOptions, CubeSecureJsonData } from '../types';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 
 const createMockEditorProps = (
-  overrides?: Partial<DataSourcePluginOptionsEditorProps<MyDataSourceOptions, MySecureJsonData>>
-): DataSourcePluginOptionsEditorProps<MyDataSourceOptions, MySecureJsonData> => {
+  overrides?: Partial<DataSourcePluginOptionsEditorProps<CubeDataSourceOptions, CubeSecureJsonData>>
+): DataSourcePluginOptionsEditorProps<CubeDataSourceOptions, CubeSecureJsonData> => {
   return {
     options: {
       id: 1,
@@ -38,7 +38,7 @@ const createMockEditorProps = (
     },
     onOptionsChange: jest.fn(),
     ...overrides,
-  } as DataSourcePluginOptionsEditorProps<MyDataSourceOptions, MySecureJsonData>;
+  } as DataSourcePluginOptionsEditorProps<CubeDataSourceOptions, CubeSecureJsonData>;
 };
 
 describe('ConfigEditor', () => {

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useMemo } from 'react';
 import { InlineField, Input, SecretInput, RadioButtonGroup, Alert, Combobox, ComboboxOption } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { MyDataSourceOptions, MySecureJsonData } from '../types';
+import { CubeDataSourceOptions, CubeSecureJsonData } from '../types';
 import { useSqlDatasourcesQuery } from 'queries';
 
 // Constants
@@ -10,7 +10,7 @@ const FIELD_WIDTHS = {
   label: 20,
 } as const;
 
-interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<MyDataSourceOptions, MySecureJsonData> {}
+interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<CubeDataSourceOptions, CubeSecureJsonData> {}
 
 export function ConfigEditor({ onOptionsChange, options }: ConfigEditorProps) {
   const { jsonData, secureJsonFields, secureJsonData } = options;
@@ -29,10 +29,10 @@ export function ConfigEditor({ onOptionsChange, options }: ConfigEditorProps) {
     [sqlDatasources]
   );
 
-  const updateJsonData = (field: keyof MyDataSourceOptions, value: string | undefined) =>
+  const updateJsonData = (field: keyof CubeDataSourceOptions, value: string | undefined) =>
     onOptionsChange({ ...options, jsonData: { ...jsonData, [field]: value } });
 
-  const updateSecureData = (field: keyof MySecureJsonData, value: string) =>
+  const updateSecureData = (field: keyof CubeSecureJsonData, value: string) =>
     onOptionsChange({ ...options, secureJsonData: { [field]: value } });
 
   const resetApiKey = () =>

--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -1,7 +1,7 @@
 import React, { act } from 'react';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryEditor } from './QueryEditor';
-import { MyQuery, Operator } from '../types';
+import { CubeQuery, Operator } from '../types';
 import { getTemplateSrv } from '@grafana/runtime';
 import { createMockDataSource, setup } from 'testUtils';
 
@@ -18,7 +18,7 @@ jest.mock('@grafana/runtime', () => ({
 
 const mockGetTemplateSrv = getTemplateSrv as jest.Mock;
 
-const createMockQuery = (overrides: Partial<MyQuery> = {}): MyQuery => ({
+const createMockQuery = (overrides: Partial<CubeQuery> = {}): CubeQuery => ({
   refId: 'A',
   ...overrides,
 });
@@ -707,14 +707,14 @@ describe('QueryEditor', () => {
       datasource.getTagValues = jest.fn().mockResolvedValue(mockMemberValues);
 
       // Track all query states to detect duplicates
-      const queryHistory: MyQuery[] = [];
+      const queryHistory: CubeQuery[] = [];
       let currentQuery = createMockQuery();
 
       // Stateful wrapper that updates props like real Grafana does
       const StatefulWrapper = () => {
         const [query, setQuery] = React.useState(currentQuery);
 
-        const handleChange = (newQuery: MyQuery) => {
+        const handleChange = (newQuery: CubeQuery) => {
           queryHistory.push({ ...newQuery });
           currentQuery = newQuery;
           setQuery(newQuery);

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -3,7 +3,7 @@ import { InlineField, Input, Alert, MultiSelect, Text, Field, useStyles2 } from 
 import { css } from '@emotion/css';
 import { GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
-import { MyDataSourceOptions, MyQuery } from '../types';
+import { CubeDataSourceOptions, CubeQuery } from '../types';
 import { SQLPreview } from './SQLPreview';
 import { useMetadataQuery, useCompiledSqlQuery, MetadataOption } from 'queries';
 import { OrderBy } from './OrderBy/OrderBy';
@@ -16,7 +16,7 @@ export function QueryEditor({
   onChange,
   onRunQuery,
   datasource,
-}: QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>) {
+}: QueryEditorProps<DataSource, CubeQuery, CubeDataSourceOptions>) {
   const styles = useStyles2(getStyles);
   const cubeQueryJson = useMemo(() => buildCubeQueryJson(query, datasource), [query, datasource]);
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,6 +1,6 @@
 import { DataSource } from './datasource';
 import { DataSourceInstanceSettings } from '@grafana/data';
-import { MyDataSourceOptions, Operator } from './types';
+import { CubeDataSourceOptions, Operator } from './types';
 import { getTemplateSrv } from '@grafana/runtime';
 
 // Mock @grafana/runtime
@@ -14,8 +14,8 @@ const mockGetTemplateSrv = getTemplateSrv as jest.Mock;
 // Mock the getResource method
 const mockGetResource = jest.fn();
 
-const createDataSource = (options: Partial<MyDataSourceOptions> = {}) => {
-  const instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions> = {
+const createDataSource = (options: Partial<CubeDataSourceOptions> = {}) => {
+  const instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions> = {
     id: 1,
     uid: 'test-uid',
     type: 'cube-datasource',

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,22 +1,22 @@
 import { DataSourceInstanceSettings, CoreApp, ScopedVars } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
-import { MyQuery, MyDataSourceOptions, DEFAULT_QUERY, CubeFilter } from './types';
+import { CubeQuery, CubeDataSourceOptions, DEFAULT_QUERY, CubeFilter } from './types';
 import { filterValidCubeFilters } from './utils/filterValidation';
 
-export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptions> {
-  readonly instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>;
+export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceOptions> {
+  readonly instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions>;
 
-  constructor(instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>) {
+  constructor(instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions>) {
     super(instanceSettings);
     this.instanceSettings = instanceSettings;
   }
 
-  getDefaultQuery(_: CoreApp): Partial<MyQuery> {
+  getDefaultQuery(_: CoreApp): Partial<CubeQuery> {
     return DEFAULT_QUERY;
   }
 
-  applyTemplateVariables(query: MyQuery, scopedVars: ScopedVars): MyQuery {
+  applyTemplateVariables(query: CubeQuery, scopedVars: ScopedVars): CubeQuery {
     const templateSrv = getTemplateSrv();
 
     // Apply template variable substitution to dimensions and measures
@@ -126,7 +126,7 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
     }
   }
 
-  filterQuery(query: MyQuery): boolean {
+  filterQuery(query: CubeQuery): boolean {
     // If no dimensions or measures have been provided, prevent the query from being executed
     return !!(query.dimensions?.length || query.measures?.length);
   }

--- a/src/hooks/useQueryEditorHandlers.ts
+++ b/src/hooks/useQueryEditorHandlers.ts
@@ -1,11 +1,11 @@
 import type { TQueryOrderArray } from '@cubejs-client/core';
 import { ChangeEvent } from 'react';
-import { MyQuery, CubeFilter, Order, DEFAULT_ORDER } from '../types';
+import { CubeQuery, CubeFilter, Order, DEFAULT_ORDER } from '../types';
 import { SelectableValue } from '@grafana/data';
 import { normalizeOrder } from '../utils/normalizeOrder';
 
-export function useQueryEditorHandlers(query: MyQuery, onChange: (query: MyQuery) => void, onRunQuery: () => void) {
-  const updateQueryAndRun = (updates: Partial<MyQuery>) => {
+export function useQueryEditorHandlers(query: CubeQuery, onChange: (query: CubeQuery) => void, onRunQuery: () => void) {
+  const updateQueryAndRun = (updates: Partial<CubeQuery>) => {
     onChange({ ...query, ...updates });
     onRunQuery();
   };

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,9 +2,9 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
-import { MyQuery, MyDataSourceOptions } from './types';
+import { CubeQuery, CubeDataSourceOptions } from './types';
 import { withQueryClient } from 'queryClient';
 
-export const plugin = new DataSourcePlugin<DataSource, MyQuery, MyDataSourceOptions>(DataSource)
+export const plugin = new DataSourcePlugin<DataSource, CubeQuery, CubeDataSourceOptions>(DataSource)
   .setConfigEditor(withQueryClient(ConfigEditor))
   .setQueryEditor(withQueryClient(QueryEditor));

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -4,7 +4,7 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { select } from 'react-select-event';
-import { MyDataSourceOptions } from 'types';
+import { CubeDataSourceOptions } from 'types';
 import { DataSource } from 'datasource';
 
 export function setup(ui: React.ReactElement) {
@@ -29,7 +29,7 @@ export function setup(ui: React.ReactElement) {
 }
 
 export const createMockDataSource = (mockMetadata: any = null, mockSQLResponse: any = null) => {
-  const instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions> = {
+  const instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions> = {
     id: 1,
     uid: 'test-uid',
     type: 'cube-datasource',

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface CubeFilter {
   values: string[];
 }
 
-export interface MyQuery extends DataQuery {
+export interface CubeQuery extends DataQuery {
   dimensions?: string[];
   measures?: string[];
   timeDimensions?: TimeDimension[];
@@ -33,7 +33,7 @@ export interface MyQuery extends DataQuery {
   order?: TQueryOrderArray | TQueryOrderObject;
 }
 
-export const DEFAULT_QUERY: Partial<MyQuery> = {};
+export const DEFAULT_QUERY: Partial<CubeQuery> = {};
 
 export interface DataPoint {
   Time: number;
@@ -47,7 +47,7 @@ export interface DataSourceResponse {
 /**
  * These are options configured for each DataSource instance
  */
-export interface MyDataSourceOptions extends DataSourceJsonData {
+export interface CubeDataSourceOptions extends DataSourceJsonData {
   cubeApiUrl?: string;
   deploymentType?: 'cloud' | 'self-hosted' | 'self-hosted-dev';
   /** UID of the SQL datasource to use when clicking "Edit SQL in Explore" */
@@ -57,7 +57,7 @@ export interface MyDataSourceOptions extends DataSourceJsonData {
 /**
  * Value that is used in the backend, but never sent over HTTP to the frontend
  */
-export interface MySecureJsonData {
+export interface CubeSecureJsonData {
   apiKey?: string; // For Cube Cloud
   apiSecret?: string; // For self-hosted Cube (JWT generation)
 }

--- a/src/utils/buildCubeQuery.ts
+++ b/src/utils/buildCubeQuery.ts
@@ -1,7 +1,7 @@
-import type { BinaryFilter, Query as CubeQuery, TimeDimension } from '@cubejs-client/core';
+import type { BinaryFilter, Query as CubeJsQuery, TimeDimension } from '@cubejs-client/core';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from '../datasource';
-import { CubeFilter, MyQuery, Operator } from '../types';
+import { CubeFilter, CubeQuery, Operator } from '../types';
 import { filterValidCubeFilters } from './filterValidation';
 import { normalizeOrder } from './normalizeOrder';
 
@@ -12,13 +12,13 @@ import { normalizeOrder } from './normalizeOrder';
  * This function uses @cubejs-client/core types to ensure compile-time
  * compatibility with Cube's /load endpoint format.
  */
-export function buildCubeQueryJson(query: MyQuery, datasource: DataSource): string {
+export function buildCubeQueryJson(query: CubeQuery, datasource: DataSource): string {
   if (!query.dimensions?.length && !query.measures?.length) {
     return '';
   }
 
-  // Using CubeQuery type for compile-time checking against Cube's official API
-  const cubeQuery: CubeQuery = {};
+  // Using CubeJsQuery type for compile-time checking against Cube's official API
+  const cubeQuery: CubeJsQuery = {};
 
   if (query.dimensions?.length) {
     cubeQuery.dimensions = query.dimensions;

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@grafana/plugin-e2e';
-import { MyDataSourceOptions, MySecureJsonData } from '../src/types';
+import { CubeDataSourceOptions, CubeSecureJsonData } from '../src/types';
 
 test('smoke: should render config editor', async ({ createDataSourceConfigPage, readProvisionedDataSource, page }) => {
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
@@ -11,7 +11,7 @@ test('"Save & test" should be successful when configuration is valid', async ({
   readProvisionedDataSource,
   page,
 }) => {
-  const ds = await readProvisionedDataSource<MyDataSourceOptions, MySecureJsonData>({ fileName: 'datasources.yml' });
+  const ds = await readProvisionedDataSource<CubeDataSourceOptions, CubeSecureJsonData>({ fileName: 'datasources.yml' });
 
   // This test expects the provisioned datasource to use self-hosted deployment
   expect(ds.jsonData.deploymentType).toBe('self-hosted');
@@ -29,7 +29,7 @@ test('"Save & test" should fail when configuration is invalid', async ({
   readProvisionedDataSource,
   page,
 }) => {
-  const ds = await readProvisionedDataSource<MyDataSourceOptions, MySecureJsonData>({ fileName: 'datasources.yml' });
+  const ds = await readProvisionedDataSource<CubeDataSourceOptions, CubeSecureJsonData>({ fileName: 'datasources.yml' });
   const configPage = await createDataSourceConfigPage({ type: ds.type });
   // Leave Cube API URL empty to trigger validation error
   await page.getByRole('textbox', { name: 'Cube API URL' }).fill('');


### PR DESCRIPTION
## Summary

- Rename project types to use consistent "Cube" prefix following Grafana plugin conventions (e.g., `InfluxQuery`, `ElasticQuery`)
- Rename external type alias to distinguish Cube.js API types from project types

| Before | After | Origin |
|--------|-------|--------|
| `MyQuery` | `CubeQuery` | Project |
| `MyDataSourceOptions` | `CubeDataSourceOptions` | Project |
| `MySecureJsonData` | `CubeSecureJsonData` | Project |
| `Query as CubeQuery` | `Query as CubeJsQuery` | @cubejs-client/core |

This resolves the inconsistency where `CubeFilter` already used the "Cube" prefix while other project types used the placeholder "My" prefix.

## Test plan

- [x] All 106 Jest tests pass
- [x] TypeScript compilation succeeds
- [x] CI passes

No version bump needed - this is a pure refactor with no runtime behavior change (TypeScript types are erased at compile time).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes type names to the "Cube" prefix and updates all references to maintain consistency with Grafana conventions.
> 
> - Renames `MyQuery`→`CubeQuery`, `MyDataSourceOptions`→`CubeDataSourceOptions`, `MySecureJsonData`→`CubeSecureJsonData`
> - Updates generics and props in `ConfigEditor`, `QueryEditor`, `DataSource`, hooks, `module.ts`, and tests
> - Changes Cube.js import alias from `Query as CubeQuery` to `Query as CubeJsQuery` in `buildCubeQuery`
> - Adjusts test utilities and e2e/spec files to new type names
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78ba720e6d1688c45539c9f32c1c9168a8bf8bab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->