### PR TITLE
JSON editor initial scope

### DIFF
--- a/src/components/JsonQueryEditor/JsonQueryEditor.test.tsx
+++ b/src/components/JsonQueryEditor/JsonQueryEditor.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { JsonQueryEditor } from './JsonQueryEditor';
+import { CubeQuery } from '../../types';
+import { UnsupportedFeature } from '../../utils/detectUnsupportedFeatures';
+import { setup } from '../../testUtils';
+
+// Mock the CodeEditor since it uses Monaco which is complex to set up in tests
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  return {
+    ...actual,
+    CodeEditor: ({ value, readOnly }: { value: string; readOnly: boolean }) => (
+      <pre data-testid="code-editor" data-readonly={readOnly}>
+        {value}
+      </pre>
+    ),
+  };
+});
+
+const createQuery = (overrides: Partial<CubeQuery> = {}): CubeQuery => ({
+  refId: 'A',
+  ...overrides,
+});
+
+describe('JsonQueryEditor', () => {
+  it('renders info alert with title', () => {
+    const query = createQuery({ dimensions: ['orders.status'] });
+    const unsupportedFeatures: UnsupportedFeature[] = [{ description: 'Time dimensions', detail: 'orders.created_at' }];
+
+    setup(<JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />);
+
+    expect(screen.getByText('Advanced query features detected')).toBeInTheDocument();
+  });
+
+  it('displays unsupported feature descriptions', () => {
+    const query = createQuery({ dimensions: ['orders.status'] });
+    const unsupportedFeatures: UnsupportedFeature[] = [
+      { description: 'Time dimensions', detail: 'orders.created_at' },
+      { description: 'Dashboard variable in dimensions', detail: '$selectedDimension' },
+    ];
+
+    setup(<JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />);
+
+    expect(screen.getByText('Time dimensions: orders.created_at')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard variable in dimensions: $selectedDimension')).toBeInTheDocument();
+  });
+
+  it('displays help text about editing via dashboard JSON', () => {
+    const query = createQuery({ dimensions: ['orders.status'] });
+    const unsupportedFeatures: UnsupportedFeature[] = [{ description: 'Time dimensions' }];
+
+    setup(<JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />);
+
+    expect(screen.getByText(/edit the dashboard JSON directly/i)).toBeInTheDocument();
+    expect(screen.getByText(/LLM/i)).toBeInTheDocument();
+  });
+
+  it('renders query JSON in code editor', () => {
+    const query = createQuery({
+      dimensions: ['orders.status'],
+      measures: ['orders.count'],
+      timeDimensions: [{ dimension: 'orders.created_at', granularity: 'day' }],
+    });
+    const unsupportedFeatures: UnsupportedFeature[] = [{ description: 'Time dimensions' }];
+
+    setup(<JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />);
+
+    const codeEditor = screen.getByTestId('code-editor');
+    expect(codeEditor).toBeInTheDocument();
+
+    // Verify JSON content contains the query fields
+    const jsonContent = codeEditor.textContent || '';
+    expect(jsonContent).toContain('"dimensions"');
+    expect(jsonContent).toContain('"orders.status"');
+    expect(jsonContent).toContain('"measures"');
+    expect(jsonContent).toContain('"orders.count"');
+    expect(jsonContent).toContain('"timeDimensions"');
+  });
+
+  it('renders code editor as read-only', () => {
+    const query = createQuery({ dimensions: ['orders.status'] });
+    const unsupportedFeatures: UnsupportedFeature[] = [{ description: 'Time dimensions' }];
+
+    setup(<JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />);
+
+    const codeEditor = screen.getByTestId('code-editor');
+    expect(codeEditor).toHaveAttribute('data-readonly', 'true');
+  });
+
+  it('excludes Grafana-internal fields from JSON display', () => {
+    const query = createQuery({
+      dimensions: ['orders.status'],
+    });
+    // Add Grafana internal fields that shouldn't appear in the JSON
+    (query as any).datasource = { uid: 'some-uid', type: 'cube' };
+    (query as any).hide = false;
+    (query as any).key = 'query-key';
+
+    const unsupportedFeatures: UnsupportedFeature[] = [{ description: 'Time dimensions' }];
+
+    setup(<JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />);
+
+    const codeEditor = screen.getByTestId('code-editor');
+    const jsonContent = codeEditor.textContent || '';
+
+    // Should contain query fields
+    expect(jsonContent).toContain('"dimensions"');
+
+    // Should NOT contain Grafana internal fields
+    expect(jsonContent).not.toContain('"refId"');
+    expect(jsonContent).not.toContain('"datasource"');
+    expect(jsonContent).not.toContain('"hide"');
+    expect(jsonContent).not.toContain('"key"');
+  });
+
+  it('handles features without detail gracefully', () => {
+    const query = createQuery({ dimensions: ['orders.status'] });
+    const unsupportedFeatures: UnsupportedFeature[] = [
+      { description: 'Complex filter groups (AND/OR logic)' }, // No detail
+    ];
+
+    setup(<JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />);
+
+    // Should display just the description without a colon
+    expect(screen.getByText('Complex filter groups (AND/OR logic)')).toBeInTheDocument();
+  });
+});

--- a/src/components/JsonQueryEditor/JsonQueryEditor.tsx
+++ b/src/components/JsonQueryEditor/JsonQueryEditor.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo } from 'react';
+import { Alert, CodeEditor, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { UnsupportedFeature } from '../../utils/detectUnsupportedFeatures';
+import { CubeQuery } from '../../types';
+
+export interface JsonQueryEditorProps {
+  /** The query to display as JSON */
+  query: CubeQuery;
+  /** List of unsupported features detected in the query */
+  unsupportedFeatures: UnsupportedFeature[];
+}
+
+/**
+ * Read-only JSON viewer for queries that contain features the visual builder cannot handle.
+ *
+ * Displays an info banner explaining why the visual builder is unavailable,
+ * followed by a read-only code editor showing the full query JSON.
+ */
+export function JsonQueryEditor({ query, unsupportedFeatures }: JsonQueryEditorProps) {
+  const styles = useStyles2(getStyles);
+
+  // Format the query as readable JSON, excluding Grafana-internal fields
+  const queryJson = useMemo(() => {
+    const { refId, datasource, hide, key, queryType, ...cubeQueryFields } = query as CubeQuery & {
+      datasource?: unknown;
+      hide?: unknown;
+      key?: unknown;
+      queryType?: unknown;
+    };
+    return JSON.stringify(cubeQueryFields, null, 2);
+  }, [query]);
+
+  const featureList = unsupportedFeatures.map((f) => (f.detail ? `${f.description}: ${f.detail}` : f.description));
+
+  return (
+    <div className={styles.container}>
+      <Alert title="Advanced query features detected" severity="info">
+        <p className={styles.description}>
+          This query uses features that the visual builder does not support. The query configuration is shown below as
+          read-only JSON.
+        </p>
+        <ul className={styles.featureList}>
+          {featureList.map((feature, index) => (
+            <li key={index}>{feature}</li>
+          ))}
+        </ul>
+        <p className={styles.helpText}>
+          To modify this query, edit the dashboard JSON directly or use an LLM to help generate valid Cube.js query
+          syntax.
+        </p>
+      </Alert>
+      <div className={styles.editorContainer}>
+        <CodeEditor
+          value={queryJson}
+          language="json"
+          height={200}
+          readOnly={true}
+          showMiniMap={false}
+          showLineNumbers={true}
+          monacoOptions={{
+            scrollBeyondLastLine: false,
+            wordWrap: 'on',
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  }),
+  description: css({
+    marginBottom: theme.spacing(1),
+  }),
+  featureList: css({
+    marginBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
+  }),
+  helpText: css({
+    marginBottom: 0,
+    fontStyle: 'italic',
+    color: theme.colors.text.secondary,
+  }),
+  editorContainer: css({
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    overflow: 'hidden',
+  }),
+});

--- a/src/components/JsonQueryEditor/index.ts
+++ b/src/components/JsonQueryEditor/index.ts
@@ -1,0 +1,1 @@
+export { JsonQueryEditor, type JsonQueryEditorProps } from './JsonQueryEditor';

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,147 +1,30 @@
 import React, { useMemo } from 'react';
-import { InlineField, Input, Alert, MultiSelect, Text, Field, useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
-import { GrafanaTheme2, QueryEditorProps } from '@grafana/data';
+import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { CubeDataSourceOptions, CubeQuery } from '../types';
-import { SQLPreview } from './SQLPreview';
-import { useMetadataQuery, useCompiledSqlQuery, MetadataOption } from 'queries';
-import { OrderBy } from './OrderBy/OrderBy';
-import { FilterField } from './FilterField/FilterField';
-import { useQueryEditorHandlers } from '../hooks/useQueryEditorHandlers';
-import { buildCubeQueryJson } from '../utils/buildCubeQuery';
+import { detectUnsupportedFeatures } from '../utils/detectUnsupportedFeatures';
+import { JsonQueryEditor } from './JsonQueryEditor';
+import { VisualQueryEditor } from './VisualQueryEditor';
 
-export function QueryEditor({
-  query,
-  onChange,
-  onRunQuery,
-  datasource,
-}: QueryEditorProps<DataSource, CubeQuery, CubeDataSourceOptions>) {
-  const styles = useStyles2(getStyles);
-  const cubeQueryJson = useMemo(() => buildCubeQueryJson(query, datasource), [query, datasource]);
+/**
+ * Main QueryEditor component that decides which editor mode to use.
+ *
+ * If the query contains unsupported features (time dimensions, dashboard variables,
+ * complex filter groups), shows a read-only JSON view.
+ *
+ * Otherwise, shows the visual query builder.
+ */
+export function QueryEditor(props: QueryEditorProps<DataSource, CubeQuery, CubeDataSourceOptions>) {
+  const { query } = props;
 
-  const { data, isLoading: metadataIsLoading, isError: metadataIsError } = useMetadataQuery({ datasource });
-  const metadata = data ?? { dimensions: [], measures: [] };
+  // Check for unsupported features before rendering visual builder
+  const unsupportedFeatures = useMemo(() => detectUnsupportedFeatures(query), [query]);
 
-  const { data: compiledSql, isLoading: compiledSqlIsLoading } = useCompiledSqlQuery({
-    datasource,
-    cubeQueryJson,
-  });
+  // If query has unsupported features, show read-only JSON view instead
+  if (unsupportedFeatures.length > 0) {
+    return <JsonQueryEditor query={query} unsupportedFeatures={unsupportedFeatures} />;
+  }
 
-  const {
-    onDimensionOrMeasureChange,
-    onLimitChange,
-    onAddOrder,
-    onRemoveOrder,
-    onToggleOrderDirection,
-    onReorderFields,
-    onFiltersChange,
-  } = useQueryEditorHandlers(query, onChange, onRunQuery);
-
-  // Map from query order to preserve user selection order (not metadata schema order)
-  const selectedDimensions = (query.dimensions || [])
-    .map((name) => metadata.dimensions.find((option) => option.value === name))
-    .filter((option): option is MetadataOption => option !== undefined);
-
-  const selectedMeasures = (query.measures || [])
-    .map((name) => metadata.measures.find((option) => option.value === name))
-    .filter((option): option is MetadataOption => option !== undefined);
-  const currentLimit = query.limit ?? '';
-
-  // All selected dimensions and measures with their labels (for OrderBy component)
-  const availableOrderOptions = useMemo(() => {
-    const selectedFields = [...(query.dimensions || []), ...(query.measures || [])];
-    return selectedFields.map((field) => ({ label: field.split('.').pop() || field, value: field }));
-  }, [query.dimensions, query.measures]);
-
-  return (
-    <>
-      {metadataIsError && <Alert title="Error fetching metadata" severity="error" />}
-      <InlineField label="Dimensions" labelWidth={16} tooltip="Select the dimensions to group your data by" grow>
-        <div className={styles.multiSelectWrapper}>
-          <div className={styles.multiSelectContainer}>
-            <MultiSelect
-              aria-label="Dimensions"
-              options={metadata.dimensions}
-              value={selectedDimensions}
-              onChange={(v) => onDimensionOrMeasureChange(v, 'dimensions')}
-              placeholder={metadataIsLoading ? 'Loading dimensions...' : 'Select dimensions...'}
-              isLoading={metadataIsLoading}
-            />
-          </div>
-        </div>
-      </InlineField>
-
-      <InlineField label="Measures" labelWidth={16} tooltip="Select the measures to aggregate" grow>
-        <div className={styles.multiSelectWrapper}>
-          <div className={styles.multiSelectContainer}>
-            <MultiSelect
-              aria-label="Measures"
-              options={metadata.measures}
-              value={selectedMeasures}
-              onChange={(v) => onDimensionOrMeasureChange(v, 'measures')}
-              placeholder={metadataIsLoading ? 'Loading measures...' : 'Select measures...'}
-              isLoading={metadataIsLoading}
-            />
-          </div>
-        </div>
-      </InlineField>
-
-      <InlineField label="Row Limit" labelWidth={16} tooltip="Maximum number of rows to return (optional)">
-        <Input
-          aria-label="Row Limit"
-          type="number"
-          value={currentLimit}
-          onChange={onLimitChange}
-          placeholder="Enter row limit..."
-          width={30}
-          min={1}
-        />
-      </InlineField>
-
-      <Field label="Filters" description="Filter results by field values">
-        <FilterField
-          filters={query.filters}
-          dimensions={metadata.dimensions}
-          onChange={onFiltersChange}
-          datasource={datasource}
-        />
-      </Field>
-
-      <Field label="Order By" description="Order results by selected fields">
-        <OrderBy
-          order={query.order}
-          availableOptions={availableOrderOptions}
-          onAdd={onAddOrder}
-          onRemove={onRemoveOrder}
-          onToggleDirection={onToggleOrderDirection}
-          onReorder={onReorderFields}
-        />
-      </Field>
-
-      {!compiledSql && compiledSqlIsLoading && (
-        <InlineField label="" labelWidth={16}>
-          <Text>Compiling SQL...</Text>
-        </InlineField>
-      )}
-
-      <SQLPreview
-        sql={compiledSql?.sql ?? ''}
-        exploreSqlDatasourceUid={datasource.instanceSettings?.jsonData?.exploreSqlDatasourceUid}
-      />
-    </>
-  );
+  // Query is compatible with visual builder
+  return <VisualQueryEditor {...props} />;
 }
-
-const getStyles = (_theme: GrafanaTheme2) => {
-  return {
-    multiSelectWrapper: css({
-      width: '100%',
-      containerType: 'inline-size',
-    }),
-    multiSelectContainer: css({
-      width: '100%',
-      minWidth: '240px',
-    }),
-  };
-};

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from 'react';
+import { InlineField, Input, Alert, MultiSelect, Text, Field, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2, QueryEditorProps } from '@grafana/data';
+import { DataSource } from '../datasource';
+import { CubeDataSourceOptions, CubeQuery } from '../types';
+import { SQLPreview } from './SQLPreview';
+import { useMetadataQuery, useCompiledSqlQuery, MetadataOption } from 'queries';
+import { OrderBy } from './OrderBy/OrderBy';
+import { FilterField } from './FilterField/FilterField';
+import { useQueryEditorHandlers } from '../hooks/useQueryEditorHandlers';
+import { buildCubeQueryJson } from '../utils/buildCubeQuery';
+
+/**
+ * Visual query builder component for Cube queries.
+ * Provides point-and-click interface for simple queries.
+ *
+ * This component assumes the query does not contain unsupported features.
+ * Use detectUnsupportedFeatures() to check before rendering.
+ */
+export function VisualQueryEditor({
+  query,
+  onChange,
+  onRunQuery,
+  datasource,
+}: QueryEditorProps<DataSource, CubeQuery, CubeDataSourceOptions>) {
+  const styles = useStyles2(getStyles);
+  const cubeQueryJson = useMemo(() => buildCubeQueryJson(query, datasource), [query, datasource]);
+
+  const { data, isLoading: metadataIsLoading, isError: metadataIsError } = useMetadataQuery({ datasource });
+  const metadata = data ?? { dimensions: [], measures: [] };
+
+  const { data: compiledSql, isLoading: compiledSqlIsLoading } = useCompiledSqlQuery({
+    datasource,
+    cubeQueryJson,
+  });
+
+  const {
+    onDimensionOrMeasureChange,
+    onLimitChange,
+    onAddOrder,
+    onRemoveOrder,
+    onToggleOrderDirection,
+    onReorderFields,
+    onFiltersChange,
+  } = useQueryEditorHandlers(query, onChange, onRunQuery);
+
+  // Map from query order to preserve user selection order (not metadata schema order)
+  const selectedDimensions = (query.dimensions || [])
+    .map((name) => metadata.dimensions.find((option) => option.value === name))
+    .filter((option): option is MetadataOption => option !== undefined);
+
+  const selectedMeasures = (query.measures || [])
+    .map((name) => metadata.measures.find((option) => option.value === name))
+    .filter((option): option is MetadataOption => option !== undefined);
+  const currentLimit = query.limit ?? '';
+
+  // All selected dimensions and measures with their labels (for OrderBy component)
+  const availableOrderOptions = useMemo(() => {
+    const selectedFields = [...(query.dimensions || []), ...(query.measures || [])];
+    return selectedFields.map((field) => ({ label: field.split('.').pop() || field, value: field }));
+  }, [query.dimensions, query.measures]);
+
+  return (
+    <>
+      {metadataIsError && <Alert title="Error fetching metadata" severity="error" />}
+      <InlineField label="Dimensions" labelWidth={16} tooltip="Select the dimensions to group your data by" grow>
+        <div className={styles.multiSelectWrapper}>
+          <div className={styles.multiSelectContainer}>
+            <MultiSelect
+              aria-label="Dimensions"
+              options={metadata.dimensions}
+              value={selectedDimensions}
+              onChange={(v) => onDimensionOrMeasureChange(v, 'dimensions')}
+              placeholder={metadataIsLoading ? 'Loading dimensions...' : 'Select dimensions...'}
+              isLoading={metadataIsLoading}
+            />
+          </div>
+        </div>
+      </InlineField>
+
+      <InlineField label="Measures" labelWidth={16} tooltip="Select the measures to aggregate" grow>
+        <div className={styles.multiSelectWrapper}>
+          <div className={styles.multiSelectContainer}>
+            <MultiSelect
+              aria-label="Measures"
+              options={metadata.measures}
+              value={selectedMeasures}
+              onChange={(v) => onDimensionOrMeasureChange(v, 'measures')}
+              placeholder={metadataIsLoading ? 'Loading measures...' : 'Select measures...'}
+              isLoading={metadataIsLoading}
+            />
+          </div>
+        </div>
+      </InlineField>
+
+      <InlineField label="Row Limit" labelWidth={16} tooltip="Maximum number of rows to return (optional)">
+        <Input
+          aria-label="Row Limit"
+          type="number"
+          value={currentLimit}
+          onChange={onLimitChange}
+          placeholder="Enter row limit..."
+          width={30}
+          min={1}
+        />
+      </InlineField>
+
+      <Field label="Filters" description="Filter results by field values">
+        <FilterField
+          filters={query.filters}
+          dimensions={metadata.dimensions}
+          onChange={onFiltersChange}
+          datasource={datasource}
+        />
+      </Field>
+
+      <Field label="Order By" description="Order results by selected fields">
+        <OrderBy
+          order={query.order}
+          availableOptions={availableOrderOptions}
+          onAdd={onAddOrder}
+          onRemove={onRemoveOrder}
+          onToggleDirection={onToggleOrderDirection}
+          onReorder={onReorderFields}
+        />
+      </Field>
+
+      {!compiledSql && compiledSqlIsLoading && (
+        <InlineField label="" labelWidth={16}>
+          <Text>Compiling SQL...</Text>
+        </InlineField>
+      )}
+
+      <SQLPreview
+        sql={compiledSql?.sql ?? ''}
+        exploreSqlDatasourceUid={datasource.instanceSettings?.jsonData?.exploreSqlDatasourceUid}
+      />
+    </>
+  );
+}
+
+const getStyles = (_theme: GrafanaTheme2) => {
+  return {
+    multiSelectWrapper: css({
+      width: '100%',
+      containerType: 'inline-size',
+    }),
+    multiSelectContainer: css({
+      width: '100%',
+      minWidth: '240px',
+    }),
+  };
+};

--- a/src/utils/detectUnsupportedFeatures.test.ts
+++ b/src/utils/detectUnsupportedFeatures.test.ts
@@ -1,0 +1,203 @@
+import { CubeQuery, Operator } from '../types';
+import { detectUnsupportedFeatures } from './detectUnsupportedFeatures';
+
+const createQuery = (overrides: Partial<CubeQuery> = {}): CubeQuery => ({
+  refId: 'A',
+  ...overrides,
+});
+
+describe('detectUnsupportedFeatures', () => {
+  describe('supported queries (visual builder can handle)', () => {
+    it('returns empty array for empty query', () => {
+      const query = createQuery();
+      expect(detectUnsupportedFeatures(query)).toEqual([]);
+    });
+
+    it('returns empty array for query with simple dimensions and measures', () => {
+      const query = createQuery({
+        dimensions: ['orders.status', 'orders.customer'],
+        measures: ['orders.count', 'orders.total'],
+      });
+      expect(detectUnsupportedFeatures(query)).toEqual([]);
+    });
+
+    it('returns empty array for query with simple filters', () => {
+      const query = createQuery({
+        dimensions: ['orders.status'],
+        filters: [
+          { member: 'orders.status', operator: Operator.Equals, values: ['completed'] },
+          { member: 'orders.customer', operator: Operator.NotEquals, values: ['test'] },
+        ],
+      });
+      expect(detectUnsupportedFeatures(query)).toEqual([]);
+    });
+
+    it('returns empty array for query with order and limit', () => {
+      const query = createQuery({
+        dimensions: ['orders.status'],
+        measures: ['orders.count'],
+        order: [['orders.count', 'desc']],
+        limit: 100,
+      });
+      expect(detectUnsupportedFeatures(query)).toEqual([]);
+    });
+  });
+
+  describe('time dimensions (unsupported)', () => {
+    it('detects time dimensions', () => {
+      const query = createQuery({
+        dimensions: ['orders.status'],
+        timeDimensions: [{ dimension: 'orders.created_at', granularity: 'day' }],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBe('Time dimensions');
+      expect(result[0].detail).toBe('orders.created_at');
+    });
+
+    it('detects multiple time dimensions', () => {
+      const query = createQuery({
+        timeDimensions: [
+          { dimension: 'orders.created_at', granularity: 'day' },
+          { dimension: 'orders.updated_at', granularity: 'hour' },
+        ],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(1);
+      expect(result[0].detail).toBe('orders.created_at, orders.updated_at');
+    });
+
+    it('ignores empty timeDimensions array', () => {
+      const query = createQuery({
+        dimensions: ['orders.status'],
+        timeDimensions: [],
+      });
+      expect(detectUnsupportedFeatures(query)).toEqual([]);
+    });
+  });
+
+  describe('dashboard variables (unsupported)', () => {
+    it('detects dashboard variable in dimensions', () => {
+      const query = createQuery({
+        dimensions: ['$selectedDimension'],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBe('Dashboard variable in dimensions');
+      expect(result[0].detail).toBe('$selectedDimension');
+    });
+
+    it('detects dashboard variable with braces in dimensions', () => {
+      const query = createQuery({
+        dimensions: ['${selectedDimension}'],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBe('Dashboard variable in dimensions');
+    });
+
+    it('detects dashboard variable in measures', () => {
+      const query = createQuery({
+        measures: ['$selectedMeasure'],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBe('Dashboard variable in measures');
+      expect(result[0].detail).toBe('$selectedMeasure');
+    });
+
+    it('detects multiple dashboard variables', () => {
+      const query = createQuery({
+        dimensions: ['$dim1', '$dim2'],
+        measures: ['$measure1'],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('complex filter groups (unsupported)', () => {
+    it('detects AND filter groups', () => {
+      const query = createQuery({
+        dimensions: ['orders.status'],
+        filters: [
+          {
+            and: [
+              { member: 'orders.status', operator: 'equals', values: ['completed'] },
+              { member: 'orders.total', operator: 'gt', values: ['100'] },
+            ],
+          } as any,
+        ],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBe('Complex filter groups (AND/OR logic)');
+      expect(result[0].detail).toBe('AND group');
+    });
+
+    it('detects OR filter groups', () => {
+      const query = createQuery({
+        dimensions: ['orders.status'],
+        filters: [
+          {
+            or: [
+              { member: 'orders.status', operator: 'equals', values: ['completed'] },
+              { member: 'orders.status', operator: 'equals', values: ['pending'] },
+            ],
+          } as any,
+        ],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBe('Complex filter groups (AND/OR logic)');
+      expect(result[0].detail).toBe('OR group');
+    });
+
+    it('reports complex filters only once even with multiple groups', () => {
+      const query = createQuery({
+        dimensions: ['orders.status'],
+        filters: [
+          { and: [{ member: 'orders.status', operator: 'equals', values: ['a'] }] } as any,
+          { or: [{ member: 'orders.status', operator: 'equals', values: ['b'] }] } as any,
+        ],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      const complexFilterFeatures = result.filter((f) => f.description.includes('Complex filter'));
+      expect(complexFilterFeatures).toHaveLength(1);
+    });
+  });
+
+  describe('multiple unsupported features', () => {
+    it('detects all unsupported features in a query', () => {
+      const query = createQuery({
+        dimensions: ['$selectedDimension'],
+        measures: ['$selectedMeasure'],
+        timeDimensions: [{ dimension: 'orders.created_at', granularity: 'day' }],
+        filters: [
+          {
+            or: [{ member: 'orders.status', operator: 'equals', values: ['a'] }],
+          } as any,
+        ],
+      });
+
+      const result = detectUnsupportedFeatures(query);
+      // 1 time dimension + 1 dimension variable + 1 measure variable + 1 complex filter = 4
+      expect(result).toHaveLength(4);
+
+      const descriptions = result.map((f) => f.description);
+      expect(descriptions).toContain('Time dimensions');
+      expect(descriptions).toContain('Dashboard variable in dimensions');
+      expect(descriptions).toContain('Dashboard variable in measures');
+      expect(descriptions).toContain('Complex filter groups (AND/OR logic)');
+    });
+  });
+});

--- a/src/utils/detectUnsupportedFeatures.ts
+++ b/src/utils/detectUnsupportedFeatures.ts
@@ -1,0 +1,96 @@
+import { CubeQuery } from '../types';
+
+/**
+ * Describes an unsupported feature detected in a query.
+ * Used to explain to users why the visual builder cannot be used.
+ */
+export interface UnsupportedFeature {
+  /** Human-readable description of the feature */
+  description: string;
+  /** The specific value that triggered the detection (for debugging) */
+  detail?: string;
+}
+
+/**
+ * Checks if a string contains a dashboard variable reference.
+ * Dashboard variables start with $ (e.g., $myVariable, ${myVariable})
+ */
+function containsDashboardVariable(value: string): boolean {
+  return value.includes('$');
+}
+
+/**
+ * Detects features in a CubeQuery that the visual query builder cannot handle.
+ *
+ * The visual builder supports:
+ * - Simple dimensions and measures (without variables)
+ * - Simple filters with equals/notEquals operators
+ * - Order by fields
+ * - Row limits
+ *
+ * The visual builder does NOT support:
+ * - Time dimensions
+ * - Dashboard variables in dimensions/measures
+ * - Complex filter groups (AND/OR logic)
+ *
+ * @param query - The CubeQuery to check
+ * @returns Array of unsupported features. Empty array means visual builder can be used.
+ */
+export function detectUnsupportedFeatures(query: CubeQuery): UnsupportedFeature[] {
+  const unsupportedFeatures: UnsupportedFeature[] = [];
+
+  // Check for time dimensions
+  if (query.timeDimensions && query.timeDimensions.length > 0) {
+    const dimensions = query.timeDimensions.map((td) => td.dimension).join(', ');
+    unsupportedFeatures.push({
+      description: 'Time dimensions',
+      detail: dimensions,
+    });
+  }
+
+  // Check for dashboard variables in dimensions
+  if (query.dimensions) {
+    for (const dimension of query.dimensions) {
+      if (containsDashboardVariable(dimension)) {
+        unsupportedFeatures.push({
+          description: 'Dashboard variable in dimensions',
+          detail: dimension,
+        });
+      }
+    }
+  }
+
+  // Check for dashboard variables in measures
+  if (query.measures) {
+    for (const measure of query.measures) {
+      if (containsDashboardVariable(measure)) {
+        unsupportedFeatures.push({
+          description: 'Dashboard variable in measures',
+          detail: measure,
+        });
+      }
+    }
+  }
+
+  // Check for complex filter groups (AND/OR logic)
+  // Cube.js supports filters with 'and'/'or' keys for nested logic
+  // Our CubeFilter type only supports simple filters, but someone could
+  // add complex filters via dashboard JSON editing
+  if (query.filters && Array.isArray(query.filters)) {
+    for (const filter of query.filters) {
+      // Check if filter has 'and' or 'or' property (complex filter group)
+      // Cast to 'any' since these properties aren't in our CubeFilter type
+      const filterAny = filter as any;
+      if (filterAny.and || filterAny.or) {
+        unsupportedFeatures.push({
+          description: 'Complex filter groups (AND/OR logic)',
+          detail: filterAny.and ? 'AND group' : 'OR group',
+        });
+        // Only report once even if multiple complex groups exist
+        break;
+      }
+    }
+  }
+
+  return unsupportedFeatures;
+}


### PR DESCRIPTION
Display read-only JSON for Cube.js queries with advanced features, guiding users to dashboard JSON or LLM for edits.

This PR addresses the core problem of hidden advanced features by providing full visibility into queries that the visual builder cannot handle (e.g., time dimensions, dashboard variables, complex filter groups). It implements a detection mechanism and a read-only JSON view, aligning with the agreed-upon minimal viable product scope to avoid the complexity of an editable JSON or a "Try Visual Editor" button for the initial release.

---
<a href="https://cursor.com/background-agent?bcId=bc-48dbb62a-6ec3-459a-b137-32e4de9f4943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48dbb62a-6ec3-459a-b137-32e4de9f4943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

