### PR TITLE
chore: remove unused dashboard variable interpolation (YAGNI)

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -161,12 +161,8 @@ describe('DataSource', () => {
   });
 
   describe('applyTemplateVariables', () => {
-    it('should interpolate template variables in filter member and values', () => {
-      // Setup mock for getTemplateSrv
+    it('should interpolate template variables in filter values', () => {
       const mockReplace = jest.fn((str: string) => {
-        if (str === '$dimension') {
-          return 'orders.status';
-        }
         if (str === '$filterValue') {
           return 'completed';
         }
@@ -182,11 +178,11 @@ describe('DataSource', () => {
 
       const query = {
         refId: 'A',
-        dimensions: ['$dimension'],
+        dimensions: ['orders.status'],
         measures: ['orders.count'],
         filters: [
           {
-            member: '$dimension',
+            member: 'orders.status',
             operator: Operator.Equals,
             values: ['$filterValue'],
           },
@@ -195,9 +191,7 @@ describe('DataSource', () => {
 
       const result = datasource.applyTemplateVariables(query, {});
 
-      // Verify filters are interpolated
       expect(result.filters).toBeDefined();
-      expect(result.filters![0].member).toBe('orders.status');
       expect(result.filters![0].values).toContain('completed');
     });
 


### PR DESCRIPTION
## Summary

Remove dashboard-variable interpolation from fields where it doesn't provide value, following YAGNI principles.

- **Dimensions**: Remove interpolation - visual builder hides unknown values anyway; let Cube error clearly
- **Measures**: Remove interpolation - same reason
- **Filter members**: Remove interpolation - visual builder uses metadata dropdown
- **Filter values**: Keep interpolation - works correctly, renders in UI as chips (e.g., `$org_id`)
- **timeDimensions**: Keep interpolation - supports `$__from`/`$__to` in dateRange
- **$cubeTimeDimension fallback**: Keep - dashboard-level time dimension injection

### Before this PR:

With Panel JSON like this:
<img width="400" height="398" alt="Screenshot 2026-01-27 at 14 30 22" src="https://github.com/user-attachments/assets/64e8c54b-215c-4f12-9c79-2bdeb7569679" />


Variables in filter-values work fine (we're keeping this functionality)
<img width="400" height="303" alt="Screenshot 2026-01-27 at 14 28 35" src="https://github.com/user-attachments/assets/d71ca835-6bf9-4dfc-9690-1a3323b41f47" />

But variables in Dimensions didn't work at all (so we're taking out this functionality):
<img width="500" height="950" alt="Screenshot 2026-01-27 at 14 27 15" src="https://github.com/user-attachments/assets/73121cf0-08f4-403c-8f96-397b924476d7" />



## Rationale

The visual query builder cannot render dashboard variables in dimensions/measures - they get hidden (showing empty dropdowns) because they don't match Cube metadata. This creates confusing "hidden configuration."

By removing interpolation for these fields, users get clear Cube API errors instead of silent failures with hidden values.

## What Users Can Still Do

- Use `$org_id` and other dashboard variables in filter values
- Use `$__from` and `$__to` in `timeDimensions[].dateRange`
- Use dashboard variables in any timeDimensions field (for simplicity of this codebase, not because we anticipate needing this functionality)
- Use `$cubeTimeDimension` dashboard variable for dashboard-wide time dimension
- Use AdHoc filters

Closes #72


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines template handling in the Cube datasource.
> 
> - Removes dashboard variable interpolation for `dimensions`, `measures`, and filter `member`; values are passed through unchanged
> - Keeps interpolation for filter `values`; AdHoc filters mapping remains the same
> - Preserves `timeDimensions` interpolation and dashboard-level `$cubeTimeDimension` injection using `$__from`/`$__to`
> - Updates tests to assert interpolation only on filter `values` and to validate time dimension injection behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1bdc53d7297d7231afff4c973c40b74d99097da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->