### PR TITLE
docs: add user documentation to README and plugin overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This plugin is experimental. Current limitations include:
 | **Technical field names** | Dimension and measure names currently use full technical identifiers (e.g., `orders.customer_name`) rather than human-readable labels. This is due to a dependency on how Grafana implements AdHoc filters. |
 | **Filter operators** | Currently only `equals` and `notEquals` are supported |
 | **Filter members** | Only dimensions can be used as filter members (no measure filtering) |
-| **Cross-panel filtering** | Currently works with Table and Bar Chart panels only |
+| **Cross-panel filtering** | Depends on Grafana AdHoc filters. Currently works with Table and Bar Chart panels only |
 
 ## Experimental Status
 

--- a/src/README.md
+++ b/src/README.md
@@ -98,7 +98,7 @@ This plugin is experimental. Current limitations include:
 | **Technical field names** | Dimension and measure names currently use full technical identifiers (e.g., `orders.customer_name`) rather than human-readable labels. This is due to a dependency on how Grafana implements AdHoc filters. |
 | **Filter operators** | Currently only `equals` and `notEquals` are supported |
 | **Filter members** | Only dimensions can be used as filter members (no measure filtering) |
-| **Cross-panel filtering** | Currently works with Table and Bar Chart panels only |
+| **Cross-panel filtering** | Depends on Grafana AdHoc filters. Currently works with Table and Bar Chart panels only |
 
 ## Experimental Status
 


### PR DESCRIPTION
## Summary

- Add comprehensive user-facing documentation to both `README.md` and `src/README.md` (plugin Overview page)
- Document experimental status, features, dashboard variables, and known limitations
- Add clickable badges for version, Grafana dependency, downloads, and license

## Documentation Sections

1. **Experimental Status** - What it means for users
2. **Why Use This Plugin** - Semantic layer benefits
3. **Features** - Query builder, filtering, ordering
4. **Dashboard Variables** - AdHoc filters, time range filtering
5. **Known Limitations** - Cube Cloud auth, technical field names, etc.
6. **Getting Started** - Plugin installation (in `src/README.md` only)

## Test plan

- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify src/README.md renders correctly on Grafana.com plugin page after publishing
- [ ] Check all links work (Cube docs, CHANGELOG, LICENSE)
- [ ] Verify badges display correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds user-facing documentation and marketplace-ready overview.
> 
> - Overhauls `README.md` and replaces template `src/README.md` with full plugin docs: purpose, features (query builder, filtering, ordering), dashboard variables (AdHoc, time range), and experimental status/limitations
> - Adds dynamic badges (Marketplace version, Grafana dependency, downloads, license) and screenshots; includes requirements, getting started, documentation, and contributing links
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e91c610d04b916bc6ccc50bce112ed6c51772267. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->