### PR TITLE
chore: release v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 3.9.0 (2026-01-27)
+
+### Features
+
+- **Cube type alignment**: Align timeDimensions and order typing with official `@cubejs-client/core` types (#64)
+- **Compile-time type checking**: Add type checking against `@cubejs-client/core` types for improved reliability (#59)
+
+### Refactoring
+
+- **Type naming conventions**: Rename types for consistency with Grafana plugin conventions (#66)
+
+### Documentation
+
+- **User documentation**: Add comprehensive user documentation to README and plugin overview (#75)
+
+### Housekeeping
+
+- Removed unused dashboard variable interpolation for dimensions/measures/filters (this was never documented or functional) (#73)
+
+**Full Changelog**: [v3.8.1...v3.9.0](https://github.com/grafana/grafana-cube-datasource/compare/v3.8.1...v3.9.0)
+
 ## 3.8.1 (2026-01-23)
 
 ### Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "3.8.1",
+      "version": "3.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

Version bump and changelog update for v3.9.0 release.

### Changes since v3.8.1

**Features:**
- Align timeDimensions and order typing with official `@cubejs-client/core` types (#64)
- Add compile-time type checking against `@cubejs-client/core` types (#59)

**Refactoring:**
- Rename types for consistency with Grafana plugin conventions (#66)

**Documentation:**
- Add comprehensive user documentation to README and plugin overview (#75)

**Housekeeping:**
- Removed unused dashboard variable interpolation (never documented or functional) (#73)

## After merging

```bash
git checkout main && git pull
git tag v3.9.0
git push origin v3.9.0
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares the v3.9.0 release.
> 
> - Bumps version to `3.9.0` in `package.json` and `package-lock.json`
> - Updates `CHANGELOG.md` with features (type alignment and compile-time checks), refactoring (type naming), documentation additions, and housekeeping notes
> - No source code changes included in this PR
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aee792cb264b39af41b4acc1c315cdff209cd6aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->