### PR TITLE
ci: skip grafana-dev image in CD Playwright tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,5 +47,8 @@ jobs:
       # - 'grafana_cloud': cloud only, hidden for on-prem users
       scopes: universal
 
+      # Skip the grafana-dev image in Playwright E2E tests (currently unavailable)
+      run-playwright-with-skip-grafana-dev-image: true
+
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to push.yaml:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs


### PR DESCRIPTION
## Summary

- Skip the `grafana-dev` image in CD Playwright E2E tests
- The `grafana-dev` image is currently unavailable, causing CD pipeline failures
- E2E tests still run against stable Grafana releases

## Test plan

- [ ] Re-run CD workflow to verify it passes with this change
- [ ] Consider removing this flag once the grafana-dev image issue is resolved upstream

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI CD workflow to avoid using the unavailable `grafana-dev` image during Playwright E2E tests.
> 
> - In `publish.yaml`, passes `run-playwright-with-skip-grafana-dev-image: true` to the shared CD workflow to skip the `grafana-dev` image during tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 735d3c44a03faa81addc935479586e0f5aad29dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->