### PR TITLE
docs: strengthen experimental status warning for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,23 @@ This plugin is experimental. Current limitations include:
 
 ## Experimental Status
 
+> **Not for production use.** This plugin is experimental and is not meant to be used in production or critical environments.
+
 This plugin is marked as **experimental**, meaning:
 
 - Features may be incomplete or have known limitations
 - Backward compatibility is not guaranteed between versions
 - The data model, configuration, or UI might change, potentially breaking dashboards
-- The plugin is primarily intended for testing, evaluation, and early feedback
+- The risks are unknown and potentially high
+- Support is limited to GitHub issues; no SLA is provided
 
-**Recommendations:**
-- Use in development or test environments before deploying to production
-- Test thoroughly, including upgrade paths
-- Avoid building hard production dependencies unless you're comfortable refactoring later
-- Track the [CHANGELOG](CHANGELOG.md) for breaking changes
+**Do not use this plugin in production environments.** It is intended for:
+- Testing and evaluation
+- Development environments
+- Providing early feedback
+- Validating use cases before production readiness
+
+Track the [CHANGELOG](CHANGELOG.md) for breaking changes and stability updates.
 
 ---
 

--- a/src/README.md
+++ b/src/README.md
@@ -102,18 +102,23 @@ This plugin is experimental. Current limitations include:
 
 ## Experimental Status
 
+> **Not for production use.** This plugin is experimental and is not meant to be used in production or critical environments.
+
 This plugin is marked as **experimental**, meaning:
 
 - Features may be incomplete or have known limitations
 - Backward compatibility is not guaranteed between versions
 - The data model, configuration, or UI might change, potentially breaking dashboards
-- The plugin is primarily intended for testing, evaluation, and early feedback
+- The risks are unknown and potentially high
+- Support is limited to GitHub issues; no SLA is provided
 
-**Recommendations:**
-- Use in development or test environments before deploying to production
-- Test thoroughly, including upgrade paths
-- Avoid building hard production dependencies unless you're comfortable refactoring later
-- Track the [changelog](https://github.com/grafana/grafana-cube-datasource/blob/main/CHANGELOG.md) for breaking changes
+**Do not use this plugin in production environments.** It is intended for:
+- Testing and evaluation
+- Development environments
+- Providing early feedback
+- Validating use cases before production readiness
+
+Track the [changelog](https://github.com/grafana/grafana-cube-datasource/blob/main/CHANGELOG.md) for breaking changes and stability updates.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Aligns experimental status documentation with [Grafana's official release lifecycle policy](https://grafana.com/docs/release-life-cycle/)
- The previous language was softer ("use in dev/test before production"), while Grafana's stance on experimental features is explicit: "not meant to be used in production"
- Updates both `README.md` and `src/README.md` (the plugin catalog documentation)

## Changes

- Add prominent "Not for production use" blockquote at the start of the section
- Change from soft recommendations to explicit prohibition: "Do not use in production environments"
- Add "risks are unknown and potentially high" — matching Grafana's release lifecycle language
- Add "Support is limited to GitHub issues; no SLA is provided" — setting clear support expectations
- Reframe intended use cases positively (testing, evaluation, feedback, validation)

## Test plan

- [x] Review updated documentation renders correctly in both READMEs
- [ ] Verify plugin catalog preview shows the updated experimental status section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Emphasizes experimental status and clarifies production restrictions in `README.md` and `src/README.md`.
> 
> - Adds a prominent `Not for production use` notice at the start of the Experimental Status section
> - Replaces soft guidance with explicit prohibition: `Do not use this plugin in production environments`
> - Notes that risks are unknown/potentially high and support is limited to GitHub issues (no SLA)
> - Updates closing guidance to intended uses (testing, evaluation, feedback, validation) and clarifies to track the `CHANGELOG` for stability updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 561d14088a19913857e8dfc8c0f320d582ff6e47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->