### PR TITLE
docs: add Cube SDK parity implementation guidance

### DIFF
--- a/.cursor/rules/sdk-parity.mdc
+++ b/.cursor/rules/sdk-parity.mdc
@@ -1,0 +1,38 @@
+---
+title: Cube SDK Parity Rules
+description: Keep Go backend behavior aligned with Cube JS SDK semantics
+globs:
+  - "pkg/plugin/**/*.go"
+alwaysApply: true
+---
+
+## Cube SDK Parity Rules
+
+This datasource backend is implemented in Go, but protocol semantics are primarily
+defined by Cube's JavaScript SDK (`@cubejs-client/core`) and Cube REST docs.
+
+## Default policy
+
+**Mirror Cube SDK behavior by default** for protocol-level behavior unless there is
+a clear Grafana/backend reason to diverge.
+
+## Required checks before implementing protocol changes
+
+When changing behavior around Cube API calls (for example `/v1/load`, retries,
+timeouts, cancellation, status/error handling, progress fields):
+
+1. Check current behavior in:
+   - Cube JS SDK (`packages/cubejs-client-core/src/index.ts` in `../cube`)
+   - Cube REST API docs (`../cube/docs/pages/product/apis-integrations/rest-api.mdx`)
+2. Compare existing plugin behavior in `pkg/plugin/datasource.go`.
+3. If intentionally diverging from SDK behavior, document:
+   - why divergence is needed,
+   - expected user impact,
+   - test coverage proving the intended behavior.
+
+## Testing expectations
+
+- Prefer behavior-focused tests (success/error/cancel paths), not timing-sensitive assertions.
+- Keep protocol tests deterministic and minimal.
+- If SDK behavior changes implementation choices, update comments so they explicitly state
+  SDK alignment or intentional divergence.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ Cube is a semantic layer that sits between your data warehouse and your applicat
    go mod tidy
    ```
 
+### Cube SDK parity guidance
+
+This plugin backend is written in Go, but Cube protocol semantics are primarily
+defined by Cube's JavaScript SDK (`@cubejs-client/core`) and Cube REST docs.
+
+When changing protocol-level behavior (for example `/v1/load` handling, retry
+behavior, timeout/cancellation semantics, status/error mapping, progress fields):
+
+- Check Cube JS SDK behavior first (local path: `../cube/packages/cubejs-client-core/src/index.ts`)
+- Check Cube REST docs (local path: `../cube/docs/pages/product/apis-integrations/rest-api.mdx`)
+- Mirror SDK behavior by default unless there is a clear Grafana/backend reason to diverge
+- If intentionally diverging, document rationale and user impact in the PR and add tests
+  that explicitly cover the divergence
+
 ### Development Workflow (Recommended)
 
 For the best development experience with automatic reloading of both frontend and backend changes:


### PR DESCRIPTION
## Summary
- Add a new Cursor rule (`.cursor/rules/sdk-parity.mdc`) for backend Go files that requires checking Cube JS SDK and Cube REST docs before protocol-level behavior changes.
- Add a `README.md` development section documenting the same SDK parity policy for human contributors.
- Define default policy: mirror SDK behavior unless there is a clear backend/Grafana reason to diverge, with documented rationale and tests.

Addresses one of the items in #118 

## Test plan
- [x] Documentation-only change (no runtime code changes)
- [x] Verified changed files are `README.md` and `.cursor/rules/sdk-parity.mdc`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/editor-rule only; no runtime or behavior changes, so functional risk is minimal.
> 
> **Overview**
> Adds a new Cursor rule (`.cursor/rules/sdk-parity.mdc`) that applies to `pkg/plugin/**/*.go`, requiring protocol-level changes to be checked against the Cube JS SDK and REST docs and documenting any intentional divergence with user impact and test coverage.
> 
> Updates `README.md` with a **Cube SDK parity guidance** section that mirrors the same expectations for human contributors when modifying `/v1/load` handling, retries/timeouts, cancellation, and status/error mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbd978181ab79368c1e6ef55c78b74491771bd1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->