### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.1.2 (2026-02-12)
+
+### Fixed in 0.1.2
+
+- Handle Cube "Continue wait" polling protocol correctly for long-running queries
+- Update non-major dependencies, including security-related updates
+
+### Changed in 0.1.2
+
+- Simplify backend test interaction patterns for better maintainability
+
+### Documentation in 0.1.2
+
+- Add Cube SDK parity guidance for backend protocol behavior
+
 ## 0.1.1 (2026-01-28)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary
- bump plugin version from `0.1.1` to `0.1.2`
- add `0.1.2` changelog entry covering fix, maintenance, and docs updates
- prepare release branch for CI validation before tagging

## Test plan
- [x] run `npm version patch --no-git-tag-version`
- [x] verify only `CHANGELOG.md`, `package.json`, and `package-lock.json` changed
- [ ] CI passes on this PR

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (version + changelog) with no runtime code modifications; low risk aside from ensuring the published version is correct.
> 
> **Overview**
> Prepares the `v0.1.2` release by bumping the plugin version from `0.1.1` to `0.1.2` in `package.json` and `package-lock.json`.
> 
> Adds a `0.1.2` `CHANGELOG.md` entry documenting fixes (Cube "Continue wait" polling for long-running queries, dependency/security updates), a backend test-maintainability change, and related documentation guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 664bd21973ee414be294f38b36a9eb01b68981d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->