### PR TITLE
feat: add view UI selection and metadata fetching

### DIFF
--- a/dev-environment/cube/model/cubes/raw_payments.yml
+++ b/dev-environment/cube/model/cubes/raw_payments.yml
@@ -3,6 +3,11 @@ cubes:
     sql_table: raw_payments
     data_source: default
 
+    joins:
+      - name: raw_orders
+        sql: '{CUBE}.order_id = {raw_orders}.id'
+        relationship: many_to_one
+
     dimensions:
       - name: id
         sql: id

--- a/dev-environment/cube/model/views/payments.yml
+++ b/dev-environment/cube/model/views/payments.yml
@@ -1,0 +1,70 @@
+# Payments view - exposes payment data with related orders and customers
+# This view provides a payment-centric perspective on the data, allowing you to
+# analyze payments alongside order and customer information.
+
+views:
+  - name: payments
+
+    cubes:
+      - join_path: raw_payments
+        includes:
+          - id
+          - order_id
+          - payment_method
+          - amount
+          - tax
+          - discount
+          - processing_fee
+          - refund_amount
+          - created_at
+          - is_successful
+          - currency
+          - total_amount
+          - total_tax
+          - total_discount
+          - total_fees
+          - avg_amount
+          - avg_tax
+          - min_amount
+          - max_amount
+          - count
+          - unique_payment_methods
+          - net_amount
+          - effective_tax_rate
+          - zero_amount_count
+          - total_refunds
+          - net_revenue
+          - count_with_discount
+          - avg_non_null_discount
+          - successful_payment_count
+          - failure_rate
+          - total_amount_in_microdollars
+          - amount_fraction_of_billion
+          - near_max_int_test
+          - scientific_notation_test
+          - tiny_decimal_test
+        prefix: true
+
+      - join_path: raw_payments.raw_orders
+        includes:
+          - status
+          - order_date
+          - created_at
+          - is_gift
+          - priority
+          - count
+          - gift_count
+          - avg_priority
+        prefix: true
+
+      - join_path: raw_payments.raw_orders.raw_customers
+        includes:
+          - first_name
+          - last_name
+          - email
+          - is_active
+          - created_at
+          - customer_segment
+          - count
+          - active_count
+        prefix: true

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -920,10 +920,12 @@ func (d *Datasource) fetchCubeMetadata(ctx context.Context, pluginContext backen
 	return &metaResponse, nil
 }
 
-// extractMetadataFromResponse extracts dimensions and measures from Cube metadata
+// extractMetadataFromResponse extracts dimensions, measures, views, and cubes from Cube metadata
 func (d *Datasource) extractMetadataFromResponse(metaResponse *CubeMetaResponse) MetadataResponse {
 	var dimensions []SelectOption
 	var measures []SelectOption
+	var viewOptions []SelectOption
+	var cubeOptions []SelectOption
 
 	// Filter to only include views from the cubes array
 	var views []CubeMeta
@@ -931,8 +933,20 @@ func (d *Datasource) extractMetadataFromResponse(metaResponse *CubeMetaResponse)
 	for _, cube := range metaResponse.Cubes {
 		if cube.Type == "view" {
 			views = append(views, cube)
+			// Add view to the views list
+			viewOptions = append(viewOptions, SelectOption{
+				Label: cube.Title,
+				Value: cube.Name,
+				Type:  "view",
+			})
 		} else {
 			cubes = append(cubes, cube)
+			// Add cube to the cubes list
+			cubeOptions = append(cubeOptions, SelectOption{
+				Label: cube.Title,
+				Value: cube.Name,
+				Type:  "cube",
+			})
 		}
 	}
 
@@ -977,11 +991,13 @@ func (d *Datasource) extractMetadataFromResponse(metaResponse *CubeMetaResponse)
 		}
 	}
 
-	backend.Logger.Debug("Extracted metadata", "dimensions", len(dimensions), "measures", len(measures))
+	backend.Logger.Debug("Extracted metadata", "dimensions", len(dimensions), "measures", len(measures), "views", len(viewOptions), "cubes", len(cubeOptions))
 
 	return MetadataResponse{
 		Dimensions: dimensions,
 		Measures:   measures,
+		Views:      viewOptions,
+		Cubes:      cubeOptions,
 	}
 }
 
@@ -1423,6 +1439,8 @@ type TagValue struct {
 type MetadataResponse struct {
 	Dimensions []SelectOption `json:"dimensions"`
 	Measures   []SelectOption `json:"measures"`
+	Views      []SelectOption `json:"views"`
+	Cubes      []SelectOption `json:"cubes"`
 }
 
 // SelectOption represents an option for select components

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,7 +1,7 @@
 import { DataSourceInstanceSettings, CoreApp, ScopedVars } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
-import { CubeQuery, CubeDataSourceOptions, DEFAULT_QUERY, CubeFilter } from './types';
+import { CubeQuery, CubeDataSourceOptions, DEFAULT_QUERY, CubeFilter, MetadataResponse } from './types';
 import { filterValidCubeFilters } from './utils/filterValidation';
 
 export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceOptions> {
@@ -164,8 +164,20 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
     });
   }
 
-  // Get available dimensions and measures for the query builder
-  getMetadata() {
+  // Get available dimensions, measures, views, and cubes for the query builder
+  getMetadata(): Promise<MetadataResponse> {
     return this.getResource('metadata');
+  }
+
+  // Get available views
+  async getViews() {
+    const metadata = await this.getMetadata();
+    return (metadata as any).views || [];
+  }
+
+  // Get available cubes
+  async getCubes() {
+    const metadata = await this.getMetadata();
+    return (metadata as any).cubes || [];
   }
 }

--- a/src/hooks/useQueryEditorHandlers.ts
+++ b/src/hooks/useQueryEditorHandlers.ts
@@ -10,8 +10,13 @@ export function useQueryEditorHandlers(query: CubeQuery, onChange: (query: CubeQ
     onRunQuery();
   };
 
-  const onDimensionOrMeasureChange = (values: Array<SelectableValue<string>>, type: 'measures' | 'dimensions') => {
+  const onDimensionOrMeasureChange = (values: Array<SelectableValue<string>>, type: 'views' | 'measures' | 'dimensions') => {
     const newValues = values.map((v) => v.value).filter((v): v is string => Boolean(v));
+
+    if (type === 'views') {
+      updateQueryAndRun({ views: newValues });
+      return;
+    }
 
     // Include newValues for the type being updated, and existing values for the other type
     const otherType = type === 'measures' ? 'dimensions' : 'measures';

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface CubeFilter {
 }
 
 export interface CubeQuery extends DataQuery {
+  views?: string[];
   dimensions?: string[];
   measures?: string[];
   timeDimensions?: TimeDimension[];
@@ -60,4 +61,17 @@ export interface CubeDataSourceOptions extends DataSourceJsonData {
 export interface CubeSecureJsonData {
   apiKey?: string; // For Cube Cloud
   apiSecret?: string; // For self-hosted Cube (JWT generation)
+}
+
+export interface SelectOption {
+  label: string;
+  value: string;
+  type?: string;
+}
+
+export interface MetadataResponse {
+  dimensions: SelectOption[];
+  measures: SelectOption[];
+  views: SelectOption[];
+  cubes: SelectOption[];
 }


### PR DESCRIPTION
## Summary
- Add view-aware selection in the query editor.
- Add metadata support for `views` and `cubes` retrieval in frontend/backend integration.
- Add Cube model/view demo updates used by the feature (`raw_payments.yml`, `payments.yml`).

## Known limitations
- Filtering is currently based on name-prefix matching between selected views and dimension/measure identifiers.
- Changing selected views does not yet proactively prune already-selected dimensions/measures that no longer match.

## Test plan
- [x] `go test ./pkg/plugin`
- [x] `npx jest src/datasource.test.ts src/components/QueryEditor.tsx --runInBand --watchAll=false`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both backend metadata parsing and the frontend query editor state/UI; mismatches between returned metadata shape and UI expectations could break query building or filtering.
> 
> **Overview**
> Adds **view-aware querying** by extending the metadata endpoint to return available `views` and `cubes` alongside dimensions/measures, and surfacing that in the query editor.
> 
> The query UI now includes a **Views** multi-select that filters the Dimensions/Measures pickers by selected view name prefixes, and query state/types are extended to persist `views`. Dev Cube model examples are updated with a `raw_payments`→`raw_orders` join and a new `payments` view to exercise the feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c12dadeccbc3f6da8370d9d82c68c134a12f422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Author
Sean Griffin <sean@sgriffin.dev>

Co-authored-by: Sean Griffin <sean@sgriffin.dev>