### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.3 (2026-02-12)
+
+### Fixed in 0.1.3
+
+- Externalize `react/jsx-runtime` and `react/jsx-dev-runtime` to keep frontend bundle behavior compatible with React 19
+- Remove invalid alerting receiver from local provisioning to unblock React 19 preview startup during validation
+
+### Changed in 0.1.3
+
+- Upgrade shared `plugin-ci-workflows` to `v6.0.0` so React 19 preview checks are included in CI by default
+
 ## 0.1.2 (2026-02-12)
 
 ### Fixed in 0.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary
- Bump plugin version from `0.1.2` to `0.1.3` without creating a tag in-branch.
- Add `0.1.3` changelog notes covering React 19 compatibility and CI workflow coverage updates.
- Prepare the release PR so CI can validate before tagging.

## Test plan
- [x] Run `npm version patch --no-git-tag-version`
- [x] Confirm `package.json` and `package-lock.json` versions are both `0.1.3`
- [x] Update `CHANGELOG.md` with `0.1.3` entry

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version and changelog/lockfile updates) with no functional code changes in this diff.
> 
> **Overview**
> Prepares the `v0.1.3` release by bumping the plugin version from `0.1.2` to `0.1.3` in `package.json` and `package-lock.json`.
> 
> Updates `CHANGELOG.md` with `0.1.3` notes covering React 19 compatibility fixes (JSX runtime externalization and local provisioning validation unblock) and a CI workflow upgrade to include React 19 preview checks by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5e96d02f17f79f067f35049e2248e68a2e01bca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->