### PR TITLE
fix(deps): remediate Dependabot alerts for lodash and qs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11149,9 +11149,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -12510,9 +12510,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,5 +86,9 @@
   "packageManager": "npm@11.9.0",
   "volta": {
     "node": "24.13.0"
+  },
+  "overrides": {
+    "lodash": "4.17.23",
+    "qs": "6.14.2"
   }
 }


### PR DESCRIPTION
## Summary
- add npm `overrides` to pin `lodash` to `4.17.23` and `qs` to `6.14.2`
- regenerate `package-lock.json` so resolved transitive versions are patched
- addresses current Dependabot alerts for `lodash` and `qs`

## Test plan
- [x] Run `npm install`
- [x] Run `npm ls lodash qs` and verify `lodash@4.17.23` and `qs@6.14.2`
- [x] Confirm only `package.json` and `package-lock.json` are changed

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and dependency pinning only; no application/runtime logic changes beyond the updated transitive packages.
> 
> **Overview**
> Pins vulnerable transitive dependencies by adding npm `overrides` for `lodash@4.17.23` and `qs@6.14.2` in `package.json`.
> 
> Regenerates `package-lock.json` so the resolved `lodash` and `qs` versions match the overrides (Dependabot remediation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb733afe50f8877cbd9dd7d51db7e8ee95d6c9d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->