### PR TITLE
fix: replace deprecated templateSrv.getAdhocFilters usage

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { InlineField, Input, Alert, MultiSelect, Text, Field, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { GrafanaTheme2, QueryEditorProps } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from '../datasource';
 import { CubeDataSourceOptions, CubeQuery } from '../types';
 import { SQLPreview } from './SQLPreview';
@@ -18,7 +19,10 @@ export function QueryEditor({
   datasource,
 }: QueryEditorProps<DataSource, CubeQuery, CubeDataSourceOptions>) {
   const styles = useStyles2(getStyles);
-  const cubeQueryJson = useMemo(() => buildCubeQueryJson(query, datasource), [query, datasource]);
+  const adHocFilters = useMemo(() => {
+    return getTemplateSrv().getAdhocFilters(datasource.name) as NonNullable<Parameters<typeof buildCubeQueryJson>[2]>;
+  }, [datasource.name]);
+  const cubeQueryJson = useMemo(() => buildCubeQueryJson(query, datasource, adHocFilters), [query, datasource, adHocFilters]);
 
   const { data, isLoading: metadataIsLoading, isError: metadataIsError } = useMetadataQuery({ datasource });
   const metadata = data ?? { dimensions: [], measures: [] };

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -161,6 +161,12 @@ describe('DataSource', () => {
   });
 
   describe('applyTemplateVariables', () => {
+    beforeEach(() => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (str: string) => str,
+      });
+    });
+
     it('should interpolate template variables in filter values', () => {
       const mockReplace = jest.fn((str: string) => {
         if (str === '$filterValue') {
@@ -171,7 +177,6 @@ describe('DataSource', () => {
 
       mockGetTemplateSrv.mockReturnValue({
         replace: mockReplace,
-        getAdhocFilters: () => [],
       });
 
       const datasource = createDataSource();
@@ -215,7 +220,6 @@ describe('DataSource', () => {
 
         mockGetTemplateSrv.mockReturnValue({
           replace: mockReplace,
-          getAdhocFilters: () => [],
         });
 
         const datasource = createDataSource();
@@ -252,7 +256,6 @@ describe('DataSource', () => {
 
         mockGetTemplateSrv.mockReturnValue({
           replace: mockReplace,
-          getAdhocFilters: () => [],
         });
 
         const datasource = createDataSource();
@@ -277,16 +280,6 @@ describe('DataSource', () => {
       });
 
       it('should not inject time dimension when $cubeTimeDimension variable is not set', () => {
-        const mockReplace = jest.fn((str: string) => {
-          // Return the variable name unchanged when not set
-          return str;
-        });
-
-        mockGetTemplateSrv.mockReturnValue({
-          replace: mockReplace,
-          getAdhocFilters: () => [],
-        });
-
         const datasource = createDataSource();
 
         const query = {
@@ -311,7 +304,6 @@ describe('DataSource', () => {
 
         mockGetTemplateSrv.mockReturnValue({
           replace: mockReplace,
-          getAdhocFilters: () => [],
         });
 
         const datasource = createDataSource();
@@ -330,13 +322,6 @@ describe('DataSource', () => {
 
     describe('AdHoc filter operators', () => {
       it('should map "One of" operator (=|) to Cube equals with multiple values', () => {
-        const mockReplace = jest.fn((str: string) => str);
-
-        mockGetTemplateSrv.mockReturnValue({
-          replace: mockReplace,
-          getAdhocFilters: () => [],
-        });
-
         const datasource = createDataSource();
 
         const query = {
@@ -364,13 +349,6 @@ describe('DataSource', () => {
       });
 
       it('should map "Not one of" operator (!=|) to Cube notEquals with multiple values', () => {
-        const mockReplace = jest.fn((str: string) => str);
-
-        mockGetTemplateSrv.mockReturnValue({
-          replace: mockReplace,
-          getAdhocFilters: () => [],
-        });
-
         const datasource = createDataSource();
 
         const query = {
@@ -398,13 +376,6 @@ describe('DataSource', () => {
       });
 
       it('should fall back to single value when values array is empty', () => {
-        const mockReplace = jest.fn((str: string) => str);
-
-        mockGetTemplateSrv.mockReturnValue({
-          replace: mockReplace,
-          getAdhocFilters: () => [],
-        });
-
         const datasource = createDataSource();
 
         const query = {
@@ -427,13 +398,6 @@ describe('DataSource', () => {
       });
 
       it('should handle standard single-value operators', () => {
-        const mockReplace = jest.fn((str: string) => str);
-
-        mockGetTemplateSrv.mockReturnValue({
-          replace: mockReplace,
-          getAdhocFilters: () => [],
-        });
-
         const datasource = createDataSource();
 
         const query = {
@@ -454,14 +418,6 @@ describe('DataSource', () => {
     });
 
     describe('filter validation', () => {
-      beforeEach(() => {
-        // Reset template srv mock to avoid AdHoc filters from previous tests
-        mockGetTemplateSrv.mockReturnValue({
-          replace: (str: string) => str,
-          getAdhocFilters: () => [],
-        });
-      });
-
       it('should strip out filters with empty values', () => {
         const datasource = createDataSource();
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -334,14 +334,7 @@ describe('DataSource', () => {
 
         mockGetTemplateSrv.mockReturnValue({
           replace: mockReplace,
-          getAdhocFilters: () => [
-            {
-              key: 'orders.status',
-              operator: '=|',
-              value: 'completed',
-              values: ['completed', 'shipped', 'delivered'],
-            },
-          ],
+          getAdhocFilters: () => [],
         });
 
         const datasource = createDataSource();
@@ -352,7 +345,14 @@ describe('DataSource', () => {
           measures: ['orders.count'],
         };
 
-        const result = datasource.applyTemplateVariables(query, {});
+        const result = datasource.applyTemplateVariables(query, {}, [
+          {
+            key: 'orders.status',
+            operator: '=|',
+            value: 'completed',
+            values: ['completed', 'shipped', 'delivered'],
+          },
+        ]);
 
         expect(result.filters).toBeDefined();
         expect(result.filters).toHaveLength(1);
@@ -368,14 +368,7 @@ describe('DataSource', () => {
 
         mockGetTemplateSrv.mockReturnValue({
           replace: mockReplace,
-          getAdhocFilters: () => [
-            {
-              key: 'orders.status',
-              operator: '!=|',
-              value: 'cancelled',
-              values: ['cancelled', 'refunded'],
-            },
-          ],
+          getAdhocFilters: () => [],
         });
 
         const datasource = createDataSource();
@@ -386,7 +379,14 @@ describe('DataSource', () => {
           measures: ['orders.count'],
         };
 
-        const result = datasource.applyTemplateVariables(query, {});
+        const result = datasource.applyTemplateVariables(query, {}, [
+          {
+            key: 'orders.status',
+            operator: '!=|',
+            value: 'cancelled',
+            values: ['cancelled', 'refunded'],
+          },
+        ]);
 
         expect(result.filters).toBeDefined();
         expect(result.filters).toHaveLength(1);
@@ -402,14 +402,7 @@ describe('DataSource', () => {
 
         mockGetTemplateSrv.mockReturnValue({
           replace: mockReplace,
-          getAdhocFilters: () => [
-            {
-              key: 'orders.status',
-              operator: '=',
-              value: 'completed',
-              values: [], // Empty values array
-            },
-          ],
+          getAdhocFilters: () => [],
         });
 
         const datasource = createDataSource();
@@ -420,7 +413,14 @@ describe('DataSource', () => {
           measures: ['orders.count'],
         };
 
-        const result = datasource.applyTemplateVariables(query, {});
+        const result = datasource.applyTemplateVariables(query, {}, [
+          {
+            key: 'orders.status',
+            operator: '=',
+            value: 'completed',
+            values: [], // Empty values array
+          },
+        ]);
 
         expect(result.filters).toBeDefined();
         expect(result.filters![0].values).toEqual(['completed']);
@@ -431,10 +431,7 @@ describe('DataSource', () => {
 
         mockGetTemplateSrv.mockReturnValue({
           replace: mockReplace,
-          getAdhocFilters: () => [
-            { key: 'orders.status', operator: '=', value: 'completed' },
-            { key: 'orders.customer', operator: '!=', value: 'test' },
-          ],
+          getAdhocFilters: () => [],
         });
 
         const datasource = createDataSource();
@@ -445,7 +442,10 @@ describe('DataSource', () => {
           measures: ['orders.count'],
         };
 
-        const result = datasource.applyTemplateVariables(query, {});
+        const result = datasource.applyTemplateVariables(query, {}, [
+          { key: 'orders.status', operator: '=', value: 'completed' },
+          { key: 'orders.customer', operator: '!=', value: 'test' },
+        ]);
 
         expect(result.filters).toHaveLength(2);
         expect(result.filters![0].operator).toBe('equals');

--- a/src/utils/buildCubeQuery.ts
+++ b/src/utils/buildCubeQuery.ts
@@ -12,7 +12,11 @@ import { normalizeOrder } from './normalizeOrder';
  * This function uses @cubejs-client/core types to ensure compile-time
  * compatibility with Cube's /load endpoint format.
  */
-export function buildCubeQueryJson(query: CubeQuery, datasource: DataSource): string {
+export function buildCubeQueryJson(
+  query: CubeQuery,
+  datasource: DataSource,
+  adHocFiltersArg?: Array<{ key: string; operator: string; value: string; values?: string[] }>
+): string {
   if (!query.dimensions?.length && !query.measures?.length) {
     return '';
   }
@@ -73,11 +77,8 @@ export function buildCubeQueryJson(query: CubeQuery, datasource: DataSource): st
   // Combine query-level filters with AdHoc filters
   let filters: CubeFilter[] = query.filters?.length ? [...query.filters] : [];
 
-  // Get AdHoc filters and convert to Cube format
-  const templateSrv = getTemplateSrv();
-  const adHocFilters = (templateSrv as any).getAdhocFilters
-    ? (templateSrv as any).getAdhocFilters(datasource.name)
-    : [];
+  // AdHoc filters may be provided by the caller (for example from request context).
+  const adHocFilters = adHocFiltersArg ?? [];
 
   if (adHocFilters && adHocFilters.length > 0) {
     const cubeFilters: CubeFilter[] = adHocFilters.map((filter: any) => ({


### PR DESCRIPTION
## BLOCKED ⚠️ 

See https://github.com/grafana/grafana/pull/75552#issuecomment-3897315211

The SQL Preview can't show the `WHERE` clauses any more 😢 

But I personally believe it's valuable to show these to our end users. Let's wait and see what Torkel and Dominik say.

## Summary
- Fixes #127
- replace deprecated runtime calls to `templateSrv.getAdhocFilters` in datasource execution paths
- switch `applyTemplateVariables` to consume request-provided AdHoc filters and keep operator mapping typed via `Operator`
- update unit tests to validate the new filter flow and remove SQL preview expectations that relied on deprecated template service access

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test:ci -- src/datasource.test.ts`
- [x] `npm run test:ci -- src/components/QueryEditor.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query construction and filter/operator mapping, so regressions could change what data is returned for dashboards using AdHoc filters or template variables.
> 
> **Overview**
> Updates AdHoc filter handling to avoid deprecated `templateSrv.getAdhocFilters()` in backend execution: `DataSource.applyTemplateVariables` and `buildCubeQueryJson` now accept request-provided AdHoc filters as an explicit argument and merge them into Cube filters.
> 
> Tightens operator typing by returning `Operator` values from `mapOperator`, and updates unit tests to pass AdHoc filters directly into `applyTemplateVariables` (simplifying template service mocks) while keeping SQL preview query building aware of AdHoc filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03db83168e4913420c524b0a5a718c1819950ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->