### PR TITLE
feat: add Data Model tab to datasource settings page

### DIFF
--- a/src/components/DataModelConfigPage.tsx
+++ b/src/components/DataModelConfigPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { PluginConfigPageProps, PluginMeta } from '@grafana/data';
+
+export function DataModelConfigPage({ plugin }: PluginConfigPageProps<PluginMeta>) {
+  return (
+    <div>
+      <h3>Data Model</h3>
+      <p>This page will let you generate Cube data models from your database schema.</p>
+      <p>Plugin ID: {plugin.meta.id}</p>
+    </div>
+  );
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,9 +2,16 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
+import { DataModelConfigPage } from './components/DataModelConfigPage';
 import { CubeQuery, CubeDataSourceOptions } from './types';
 import { withQueryClient } from 'queryClient';
 
 export const plugin = new DataSourcePlugin<DataSource, CubeQuery, CubeDataSourceOptions>(DataSource)
   .setConfigEditor(withQueryClient(ConfigEditor))
-  .setQueryEditor(withQueryClient(QueryEditor));
+  .setQueryEditor(withQueryClient(QueryEditor))
+  .addConfigPage({
+    title: 'Data Model',
+    id: 'data-model',
+    icon: 'cube',
+    body: DataModelConfigPage,
+  });


### PR DESCRIPTION
## Summary

- Adds a "Data Model" tab to the datasource settings page via the `addConfigPage()` plugin API
- Tab appears between Settings and Permissions
- Currently renders a placeholder; the full data model generation UI (database tree, table selection, schema generation) will be added in follow-up commits

## Grafana bug discovered

While implementing this, we discovered that Grafana's `DataSourceTabPage` hardcodes `'settings'` when resolving the active tab, so the tab indicator doesn't follow custom config pages. The tab content renders correctly -- it's just the visual highlight that stays on Settings.

Filed as: https://github.com/grafana/grafana/issues/118105

This PR can serve as a reproduction case for that issue.

## Test plan

- [ ] Navigate to datasource settings page
- [ ] Verify "Data Model" tab appears between Settings and Permissions
- [ ] Click "Data Model" tab -- content renders, URL updates to `?page=data-model`
- [ ] Note: active tab indicator stays on Settings (known Grafana bug)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new UI entry point but no data handling or query logic; risk is limited to plugin settings navigation/rendering.
> 
> **Overview**
> Adds a new datasource config page via `addConfigPage()` so users see a **Data Model** tab in settings.
> 
> Introduces `DataModelConfigPage` as a placeholder React view (currently static text + plugin id) and registers it in `src/module.ts` with id `data-model` and icon `cube`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0fe64efc35aa795e7bff00d89d656663eeef2bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->