### PR TITLE
refactor: share cube query normalization across execution and SQL preview

### DIFF
--- a/src/utils/normalizeCubeQuery.ts
+++ b/src/utils/normalizeCubeQuery.ts
@@ -1,0 +1,179 @@
+import type { TimeDimension } from '@cubejs-client/core';
+import type { ScopedVars } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+import { CubeFilter, CubeFilterItem, CubeQuery, Operator, UNARY_OPERATORS, isCubeAndFilter, isCubeFilter, isCubeOrFilter } from '../types';
+import { filterValidCubeFilters } from './filterValidation';
+import { normalizeOrder, OrderArray } from './normalizeOrder';
+
+interface AdHocFilter {
+  key: string;
+  operator: string;
+  value: string;
+  values?: string[];
+}
+
+interface NormalizeCubeQueryOptions {
+  datasourceName: string;
+  mapOperator: (grafanaOperator: string) => Operator;
+  scopedVars?: ScopedVars;
+}
+
+export interface NormalizedCubeQuery {
+  dimensions?: string[];
+  measures?: string[];
+  timeDimensions?: TimeDimension[];
+  filters?: CubeFilterItem[];
+  order?: OrderArray;
+  limit?: number;
+}
+
+/**
+ * Produces a normalized Cube query shape shared by:
+ * - runtime execution (applyTemplateVariables)
+ * - SQL preview compilation (buildCubeQueryJson)
+ *
+ * Keeping this logic centralized prevents preview/runtime drift.
+ */
+export function normalizeCubeQuery(query: CubeQuery, options: NormalizeCubeQueryOptions): NormalizedCubeQuery {
+  const templateSrv = getTemplateSrv();
+  const scopedVars = options.scopedVars ?? {};
+
+  const interpolatedFilters = query.filters?.map((item) => interpolateFilterItem(item, templateSrv, scopedVars)) ?? [];
+  const adHocFilters = getAdHocFilters(templateSrv, options.datasourceName).map((filter): CubeFilter => ({
+    member: filter.key,
+    operator: options.mapOperator(filter.operator),
+    // Multi-value operators (=| and !=|) use values array; otherwise fall back to single value.
+    values: filter.values && filter.values.length > 0 ? filter.values : [filter.value],
+  }));
+
+  const validFilters = filterValidCubeFilters([...interpolatedFilters, ...adHocFilters]).map(stripUnaryFilterValues);
+
+  const queryTimeDimensions = interpolateTimeDimensions(query.timeDimensions, templateSrv, scopedVars);
+  const timeDimensions = queryTimeDimensions?.length ? queryTimeDimensions : injectDashboardTimeDimension(templateSrv, scopedVars);
+
+  return {
+    dimensions: query.dimensions?.length ? query.dimensions : undefined,
+    measures: query.measures?.length ? query.measures : undefined,
+    timeDimensions,
+    filters: validFilters.length > 0 ? validFilters : undefined,
+    order: normalizeOrder(query.order),
+    limit: query.limit ?? undefined,
+  };
+}
+
+function interpolateFilterItem(
+  item: CubeFilterItem,
+  templateSrv: ReturnType<typeof getTemplateSrv>,
+  scopedVars: ScopedVars
+): CubeFilterItem {
+  if (isCubeFilter(item)) {
+    return {
+      ...item,
+      values: item.values?.map((value) => templateSrv.replace(value, scopedVars)),
+    };
+  }
+
+  if (isCubeAndFilter(item)) {
+    return { and: item.and.map((child) => interpolateFilterItem(child, templateSrv, scopedVars)) };
+  }
+
+  if (isCubeOrFilter(item)) {
+    return { or: item.or.map((child) => interpolateFilterItem(child, templateSrv, scopedVars)) };
+  }
+
+  return item;
+}
+
+function stripUnaryFilterValues(item: CubeFilterItem): CubeFilterItem {
+  if (isCubeFilter(item)) {
+    if (!UNARY_OPERATORS.has(item.operator)) {
+      return item;
+    }
+    return { member: item.member, operator: item.operator };
+  }
+
+  if (isCubeAndFilter(item)) {
+    return { and: item.and.map(stripUnaryFilterValues) };
+  }
+
+  if (isCubeOrFilter(item)) {
+    return { or: item.or.map(stripUnaryFilterValues) };
+  }
+
+  return item;
+}
+
+function interpolateTimeDimensions(
+  timeDimensions: CubeQuery['timeDimensions'],
+  templateSrv: ReturnType<typeof getTemplateSrv>,
+  scopedVars: ScopedVars
+): TimeDimension[] | undefined {
+  if (!timeDimensions?.length) {
+    return undefined;
+  }
+
+  return timeDimensions.map((timeDimension) => {
+    const rawTimeDimension = timeDimension as unknown as Record<string, unknown>;
+    const interpolated = Object.fromEntries(
+      Object.entries(rawTimeDimension).map(([key, value]) => {
+        if (typeof value === 'string') {
+          return [key, templateSrv.replace(value, scopedVars)];
+        }
+
+        if (Array.isArray(value)) {
+          return [
+            key,
+            value.map((entry) => (typeof entry === 'string' ? templateSrv.replace(entry, scopedVars) : entry)),
+          ];
+        }
+
+        return [key, value];
+      })
+    );
+
+    return interpolated as unknown as TimeDimension;
+  });
+}
+
+function injectDashboardTimeDimension(
+  templateSrv: ReturnType<typeof getTemplateSrv>,
+  scopedVars: ScopedVars
+): TimeDimension[] | undefined {
+  const dashboardTimeDimension = templateSrv.replace('$cubeTimeDimension', scopedVars);
+  if (!dashboardTimeDimension || dashboardTimeDimension === '$cubeTimeDimension') {
+    return undefined;
+  }
+
+  const fromTime = templateSrv.replace('$__from', scopedVars);
+  const toTime = templateSrv.replace('$__to', scopedVars);
+  if (!fromTime || !toTime || fromTime === '$__from' || toTime === '$__to') {
+    return undefined;
+  }
+
+  const fromTimestamp = parseInt(fromTime, 10);
+  const toTimestamp = parseInt(toTime, 10);
+  if (Number.isNaN(fromTimestamp) || Number.isNaN(toTimestamp)) {
+    return undefined;
+  }
+
+  const fromDate = new Date(fromTimestamp);
+  const toDate = new Date(toTimestamp);
+  if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
+    return undefined;
+  }
+
+  return [
+    {
+      dimension: dashboardTimeDimension,
+      dateRange: [fromDate.toISOString(), toDate.toISOString()],
+    },
+  ];
+}
+
+function getAdHocFilters(templateSrv: ReturnType<typeof getTemplateSrv>, datasourceName: string): AdHocFilter[] {
+  const withAdHoc = templateSrv as ReturnType<typeof getTemplateSrv> & {
+    getAdhocFilters?: (name: string) => AdHocFilter[] | undefined;
+  };
+
+  return withAdHoc.getAdhocFilters?.(datasourceName) ?? [];
+}


### PR DESCRIPTION
## Summary

This refactor centralizes Cube query normalization so the runtime execution path and SQL preview path use the same logic.

Before this change, normalization logic was split between:
- `DataSource.applyTemplateVariables(...)` (runtime execution)
- `buildCubeQueryJson(...)` (SQL preview)

That made it easy for behavior to drift.

## Why

We had subtle inconsistencies between preview and runtime behavior (especially around variables, order, and edge-case filters). This PR reduces that drift and makes query shaping easier to maintain.

## What changed

### New shared utility
- Added `src/utils/normalizeCubeQuery.ts` with a single normalization flow for:
  - filter value interpolation
  - AdHoc filter merge + operator mapping
  - filter validation
  - unary filter normalization (`set` / `notSet` strip `values`)
  - time dimension interpolation
  - dashboard `$cubeTimeDimension` injection
  - safe timestamp guards for `$__from` / `$__to`
  - order normalization (`object` -> `array`, drop invalid directions)
  - limit passthrough (including `0`)

### Existing callers now share it
- `src/datasource.ts`
  - `applyTemplateVariables(...)` now uses `normalizeCubeQuery(...)`
- `src/utils/buildCubeQuery.ts`
  - `buildCubeQueryJson(...)` now uses `normalizeCubeQuery(...)`

## Behavior impact

- Runtime and SQL preview now produce aligned normalized query shapes.
- Legacy object `order` format is normalized consistently in runtime and preview.
- Invalid dashboard time vars (`$__from` / `$__to`) no longer cause bad injected time dimensions.
- Unary operators are normalized consistently without extraneous `values`.

## Non-goals

- No new heavy validation framework.
- No changes to unsupported-feature detection / JSON viewer mode switching.
- Still relies on Cube API for deep semantic validation.

## Tests

Added/updated tests:
- `src/utils/buildCubeQuery.test.ts`
  - normalizes legacy object order
  - skips injected timeDimension when dashboard time vars are invalid
- `src/datasource.test.ts`
  - runtime order normalization parity
  - unary operator value stripping parity
  - invalid dashboard time vars handling

Verification run:
- `npm run typecheck`
- `npm run test:ci -- src/utils/buildCubeQuery.test.ts src/datasource.test.ts`
- `npm run test:ci -- src/components/QueryEditor.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query-shaping used by both runtime execution and SQL preview; while mostly a refactor with added test coverage, subtle normalization changes could alter generated Cube queries in edge cases (filters/time range/order).
> 
> **Overview**
> **Unifies Cube query normalization** by introducing `normalizeCubeQuery` and using it from both `DataSource.applyTemplateVariables` (runtime) and `buildCubeQueryJson` (SQL preview), reducing drift between previewed SQL and executed queries.
> 
> Normalization now consistently interpolates filter values, merges AdHoc filters, validates/cleans filters (including stripping `values` from unary operators), interpolates time dimensions and safely injects `$cubeTimeDimension` only when `$__from/$__to` parse as valid timestamps, and normalizes legacy `order` object format to the array form. Tests were updated/added to lock in parity for invalid time vars, unary filter cleanup, and order normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b55c61a2485693586956e3d420f52b2f0fb29bd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->