### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,22 @@
 
 ## Unreleased
 
+## 0.2.0 (2026-02-18)
+
 ### Features
 
-- **JSON query viewer**: When a query contains features the visual editor cannot represent (e.g. time dimensions), the query editor switches to a read-only JSON viewer with syntax highlighting and a compiled SQL preview (#58)
-- **All Cube filter operators**: Support all Cube filter operators (`contains`, `gt`, `gte`, `lt`, `lte`, `set`, `notSet`, `inDateRange`, and more) and measure filters via panel JSON (#58)
-- **AND/OR filter groups**: Support logical AND/OR filter groups for complex conditions via panel JSON (#58)
-- **Advanced filter hint**: The visual builder shows a hint linking to the Cube filter docs for users who need advanced filtering features
+- **Data Model config page**: Full config page for generating Cube data model YAML files from connected database schemas (#132)
+- **JSON query viewer**: When a query contains features the visual editor cannot represent (e.g. time dimensions), the query editor switches to a read-only JSON viewer with syntax highlighting and a compiled SQL preview (#136)
+- **All Cube filter operators**: Support all Cube filter operators (`contains`, `gt`, `gte`, `lt`, `lte`, `set`, `notSet`, `inDateRange`, and more) and measure filters via panel JSON (#138)
+- **AND/OR filter groups**: Support logical AND/OR filter groups for complex conditions via panel JSON (#139)
+- **Template variable detection in filters**: Filter values containing template variables automatically trigger the JSON viewer to avoid corrupting the variable syntax (#140)
+- **No-cubes guidance**: When no cubes are detected, the query editor guides users to the Data Model configuration tab (#148)
+
+### Bug Fixes
+
+- **Preserve limit zero and legacy template vars**: Correctly handle `limit: 0` (unlimited) and detect legacy `$variable` template variable syntax (#143)
+
+**Full Changelog**: [v0.1.4...v0.2.0](https://github.com/grafana/grafana-cube-datasource/compare/v0.1.4...v0.2.0)
 
 ## 0.1.4 (2026-02-13)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

Version bump to v0.2.0 with changelog update.

### Notable changes since v0.1.4

- Data Model config page with full generate flow
- JSON query viewer for unsupported visual builder features
- Full Cube filter operator and AND/OR filter group support
- Template variable detection in filter values
- No-cubes guidance directing users to Data Model tab
- Fix for limit zero preservation and legacy template var detection

## Post-merge

After CI passes and this PR is merged, tag the release on main:

```bash
git checkout main && git pull
git tag v0.2.0
git push origin v0.2.0
```


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only changes (changelog + version bump) with no runtime code modifications.
> 
> **Overview**
> Prepares the `v0.2.0` release by adding the `0.2.0 (2026-02-18)` section to `CHANGELOG.md`, including feature and bug-fix highlights and a comparison link.
> 
> Bumps the package version from `0.1.4` to `0.2.0` in `package.json` and `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3546e54e575570e64c55318c81c126fa4f815226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->