### PR TITLE
Add dashboard for generated data model

### DIFF
--- a/provisioning/dashboards/cube-ds-generate-data-model.json
+++ b/provisioning/dashboards/cube-ds-generate-data-model.json
@@ -21,6 +21,31 @@
   "links": [],
   "panels": [
     {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# Basic dashboard to support auto-generated Cube Data Model\n\nThis dashboard uses the minimum of dimensions and measures\nthat are provided when the data model is automatically generated\nby Cube from this URL:\n\nhttp://localhost:3000/connections/datasources/edit/cube-datasource/?page=data-model\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "13.0.0-22160373891",
+      "title": "",
+      "type": "text"
+    },
+    {
       "datasource": {
         "type": "grafana-cube-datasource",
         "uid": "cube-datasource"
@@ -68,7 +93,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 4
       },
       "id": 1,
       "options": {
@@ -160,7 +185,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 4
       },
       "id": 2,
       "options": {
@@ -241,7 +266,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 11
+        "y": 15
       },
       "id": 3,
       "options": {
@@ -330,7 +355,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 11
+        "y": 15
       },
       "id": 4,
       "options": {
@@ -406,6 +431,6 @@
   "timezone": "browser",
   "title": "Cube DS, via 'Generate data model' button",
   "uid": "cube-ds-via-generate-data-model-button",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Adds a dashboard that works OOTB with the generated data model.

Cube generated data model can be found here:

http://localhost:3000/connections/datasources/edit/cube-datasource/?page=data-model
<img width="915" height="835" alt="Screenshot 2026-03-11 at 10 01 47" src="https://github.com/user-attachments/assets/bfbd5c32-e36d-4cd4-9aa7-602593f8db99" />

The new dashboard that this PR creates can be found here:
http://localhost:3000/d/cube-ds-via-generate-data-model-button
<img width="1459" height="1240" alt="image" src="https://github.com/user-attachments/assets/50012c26-df3b-42ed-9b44-fd2d666d89fc" />

So this allows us to demo Data Model generation, and immediately show not just working queries, but an entire working dashboard.

Commits:

- **Add dashboard configured for the "Generate data model" workflow**
- **Update the json, by copying it from Grafana**
- **Add top panel explaining what this dash is for**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new provisioned dashboard JSON only, with no changes to runtime code paths or data handling.
> 
> **Overview**
> Adds a new provisioned Grafana dashboard, `cube-ds-generate-data-model.json`, intended to demo Cube’s **"Generate data model"** workflow.
> 
> The dashboard includes an explanatory text panel plus a small set of example visualizations (bar charts, table, time series) wired to the `grafana-cube-datasource` (`uid: cube-datasource`) and a `cubeTimeDimension` variable for time-range filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c2f2c90f9f0a83cd717a10afee5b5c2b974d14f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->