### PR TITLE
E2E test datasource URL

### DIFF
--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -11,13 +11,15 @@ test('"Save & test" should be successful when configuration is valid', async ({
   readProvisionedDataSource,
   page,
 }) => {
-  const ds = await readProvisionedDataSource<CubeDataSourceOptions, CubeSecureJsonData>({ fileName: 'datasources.yml' });
+  const ds = await readProvisionedDataSource<CubeDataSourceOptions, CubeSecureJsonData>({
+    fileName: 'datasources.yml',
+  });
 
   // This test expects the provisioned datasource to use self-hosted deployment
   expect(ds.jsonData.deploymentType).toBe('self-hosted');
 
   const configPage = await createDataSourceConfigPage({ type: ds.type });
-  await page.getByRole('textbox', { name: 'Cube API URL' }).fill(ds.jsonData.cubeApiUrl ?? '');
+  await page.getByRole('textbox', { name: 'Cube API URL' }).fill(ds.url ?? '');
   await page.getByRole('radio', { name: 'Self-hosted (API Secret)' }).click();
   await page.getByRole('textbox', { name: 'API Secret' }).fill(ds.secureJsonData?.apiSecret ?? '');
 
@@ -29,7 +31,9 @@ test('"Save & test" should fail when configuration is invalid', async ({
   readProvisionedDataSource,
   page,
 }) => {
-  const ds = await readProvisionedDataSource<CubeDataSourceOptions, CubeSecureJsonData>({ fileName: 'datasources.yml' });
+  const ds = await readProvisionedDataSource<CubeDataSourceOptions, CubeSecureJsonData>({
+    fileName: 'datasources.yml',
+  });
   const configPage = await createDataSourceConfigPage({ type: ds.type });
   // Leave Cube API URL empty to trigger validation error
   await page.getByRole('textbox', { name: 'Cube API URL' }).fill('');


### PR DESCRIPTION
Fix E2E test to correctly read Cube API URL from the top-level `url` field.

The test was failing because a provisioning change moved the Cube API URL from `jsonData.cubeApiUrl` to `url`, causing the test to fill an empty string and fail validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that updates where a form value is sourced; no production logic or security-sensitive paths are modified.
> 
> **Overview**
> Updates the config editor E2E test to fill the **Cube API URL** input from the provisioned datasource’s top-level `url` field (instead of `jsonData.cubeApiUrl`), aligning with updated provisioning and preventing false validation failures.
> 
> Also reformats the `readProvisionedDataSource` calls for readability (no functional change beyond the URL source).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e967108cfae162564fc29063f1fcddd75a81177. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->