### PR TITLE
feat(dashboards): refresh provisioned demo dashboards

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
         grafana_version: ${GRAFANA_VERSION:-12.3.3}
         grafana_image: ${GRAFANA_IMAGE:-grafana}
     environment:
-      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cube-datasource-poc.json
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cubeds-ecom-full-data-model.json
       GF_FEATURE_TOGGLES_ENABLE: 'tableNextGen,queryLibrary,sqlExpressions,dashboardDsAdHocFiltering,adhocFiltersInTooltips'
     depends_on:
       - cube

--- a/provisioning/alerting/alert_rules.yaml
+++ b/provisioning/alerting/alert_rules.yaml
@@ -77,13 +77,13 @@ groups:
               maxDataPoints: 43200
               refId: C
               type: threshold
-        dashboardUid: cube-datasource-poc
+        dashboardUid: cubeds-ecom-full-data-model
         panelId: 2
         noDataState: NoData
         execErrState: Error
         for: 1m
         annotations:
-          __dashboardUid__: cube-datasource-poc
+          __dashboardUid__: cubeds-ecom-full-data-model
           __panelId__: '2'
         labels: {}
         isPaused: false

--- a/provisioning/dashboards/cubeds-ecom-full-data-model.json
+++ b/provisioning/dashboards/cubeds-ecom-full-data-model.json
@@ -964,8 +964,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Cube Datasource PoC",
-  "uid": "cube-datasource-poc",
+  "title": "CubeDS e-commerce: Full Data Model",
+  "uid": "cubeds-ecom-full-data-model",
   "version": 4,
   "weekStart": ""
 }

--- a/provisioning/dashboards/cubeds-ecom-generated-data-model.json
+++ b/provisioning/dashboards/cubeds-ecom-generated-data-model.json
@@ -429,8 +429,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Cube DS, via 'Generate data model' button",
-  "uid": "cube-ds-via-generate-data-model-button",
+  "title": "CubeDS e-commerce: Generated Data Model",
+  "uid": "cubeds-ecom-generated-data-model",
   "version": 2,
   "weekStart": ""
 }

--- a/provisioning/dashboards/territory-navigator.json
+++ b/provisioning/dashboards/territory-navigator.json
@@ -1,0 +1,6844 @@
+{
+  "uid": "territory-navigator",
+  "title": "GrafanaCon2026 RevOps use-case",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 1,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 17,
+        "x": 0,
+        "y": 0
+      },
+      "id": 47,
+      "options": {
+        "afterRender": "",
+        "content": "<div style=\"float: left; margin-right: 20px;\">\n  <img src=\"http://samuelgaren.com/grafana/dashboard_assets/logo_territory_navigator.png\" style=\"height: 80px; padding-top: 10px;\"/>\n</div>\n\n<div style=\"float: left;\">\n  <p style=\"font-size: 32px; margin: 0;\">Territory Navigator</p>\n  <p style=\"font-size: 24px;\">v1.4</p>\n</div>",
+        "contentPartials": [],
+        "defaultContent": "The query didn't return any results.",
+        "editor": {
+          "format": "auto",
+          "height": 200,
+          "language": "html"
+        },
+        "editors": [],
+        "externalScripts": [],
+        "externalStyles": [],
+        "helpers": "",
+        "renderMode": "everyRow",
+        "styles": "",
+        "wrap": false
+      },
+      "pluginVersion": "6.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "select 0 as test",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": true,
+      "type": "marcusolsson-dynamictext-panel"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 57496,
+      "title": "Summary (# of Accounts)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "displayName": "Accounts",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "/.*/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect count(a.account_id) as ct\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#eca464",
+            "mode": "fixed"
+          },
+          "displayName": "$ Qualified Pipeline (Net NACV)",
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 5,
+        "y": 4
+      },
+      "id": 54,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(net_nacv_split) as val\n\nfrom territory_nav.revops_reporting_opp_split as o\n\ninner join account_filter_cte on account_filter_cte.account_id = o.account_id\n\nwhere stage_number between 3 and 6\n  and net_nacv_ttl > 0",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5f7fde",
+            "mode": "fixed"
+          },
+          "displayName": "$ Closed / Won (Net NACV)",
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 10,
+        "y": 4
+      },
+      "id": 69,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(net_nacv_split) as val\n\nfrom territory_nav.revops_reporting_opp_split as o\n\ninner join account_filter_cte on account_filter_cte.account_id = o.account_id\n\nwhere stage_number = 7\n  and close_date between '${__from:date}'::date and '${__to:date}'::date\n\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#c06bcb",
+            "mode": "fixed"
+          },
+          "displayName": "Engaged by AE / SDR Last 90 Days",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 15,
+        "y": 4
+      },
+      "id": 103,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect count(distinct(a.account_id)) as ct\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte as f on f.account_id = a.account_id\n\nwhere has_ae_sdr_meeting\n  or has_other_ae_sdr_engagement",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#9282e9",
+            "mode": "fixed"
+          },
+          "displayName": "Opt-Ins",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "id": 149,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "/.*/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(ct_opt_ins_marketing_ops) as ct\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ct_contracted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5f7fde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ct_prospect"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9282e9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ct_cold"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5c5c6f",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 8
+      },
+      "id": 98,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect count(CASE WHEN a.account_funnel_score_number = 1 THEN a.account_id ELSE null END) as ct_contracted\n  , count(CASE WHEN a.account_funnel_score_number != 1 THEN a.account_id ELSE null END) as ct_prospect\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "ct_cold": "Cold Accounts",
+              "ct_contracted": "Customers",
+              "ct_prospect": "Prospects"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#eca464",
+            "mode": "fixed"
+          },
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "share_accts_qp"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "noValue",
+                "value": "0%"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 5,
+        "y": 8
+      },
+      "id": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect count(distinct(CASE WHEN stage_number between 3 and 6 and net_nacv_ttl > 0 THEN o.account_id ELSE null END)) as ct_accts_qp\n  , (count(distinct(CASE WHEN stage_number between 3 and 6 and net_nacv_ttl > 0 THEN o.account_id ELSE null END)))::numeric / NULLIF(count(distinct(o.account_id)), 0) as share_accts_qp\n\nfrom territory_nav.revops_reporting_opp_split as o\n\ninner join account_filter_cte on account_filter_cte.account_id = o.account_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "ct_accts": "Accts w/ Qualified Pipeline",
+              "ct_accts_qp": "w/ QP",
+              "ct_opps": "Opportunities in Qualified Pipeline",
+              "share_accts_qp": "% w/ QP",
+              "val_opps": "Net NACV + Services in Qualified Pipeline"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5f7fde",
+            "mode": "fixed"
+          },
+          "noValue": "0 Opps Closed / Won",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "New (New Logo)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9282e9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "New (SS → Contracted)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#c06bcb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expansion"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#df6985",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 10,
+        "y": 8
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect opp_type_qbr\n  , count(distinct(o.account_id)) as ct_accts\n\nfrom territory_nav.revops_reporting_opp_split as o\n\ninner join account_filter_cte on account_filter_cte.account_id = o.account_id\n\nwhere stage_number = 7\n  and net_nacv_ttl > 0\n  and close_date between '${__from:date}'::date and '${__to:date}'::date\n\nGROUP BY 1",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "opp_type_qbr",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "ct_accts",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Expansion": 2,
+              "New (New Logo)": 0,
+              "New (SS → Contracted)": 1
+            },
+            "renameByName": {
+              "Expansion": "w/ Expansion",
+              "New (New Logo)": "w/ New Logo",
+              "New (SS → Contracted)": "w/ New SS → Contracted"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#c06bcb",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 15,
+        "y": 8
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect count(distinct(CASE WHEN has_ae_sdr_meeting THEN a.account_id ELSE null END)) as ct_ae_sdr_meeting\n  , count(distinct(CASE WHEN has_other_ae_sdr_engagement AND NOT has_ae_sdr_meeting THEN a.account_id ELSE null END)) as ct_other_ae_sdr_engagement\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte as f on f.account_id = a.account_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "ct_ae_sdr_meeting": "w/ AE / SDR Meeting",
+              "ct_mtg": "w/ AE / SDR Meeting",
+              "ct_other_ae_sdr_engagement": "w/ AE / SDR Call / Msg",
+              "ct_other_contact": "w/ AE / SDR Msg / Call"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#9282e9",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "displayName": "% Contacted, Last 6 Months",
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#9282e9",
+                "value": 0
+              },
+              {
+                "color": "#c06bcb",
+                "value": 0.33
+              },
+              {
+                "color": "#df6985",
+                "value": 0.66
+              },
+              {
+                "color": "#e76a6b",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 8
+      },
+      "id": 150,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "/.*/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect (sum(coalesce(ct_opt_ins_contacted_l6m_marketing_ops, 0)))::numeric / NULLIF(sum(coalesce(ct_opt_ins_marketing_ops, 0)), 0) as share\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 99,
+      "options": {
+        "infinitePan": false,
+        "inlineEditing": true,
+        "panZoom": false,
+        "root": {
+          "background": {
+            "color": {
+              "fixed": "transparent"
+            }
+          },
+          "border": {
+            "color": {
+              "fixed": "dark-green"
+            }
+          },
+          "constraint": {
+            "horizontal": "left",
+            "vertical": "top"
+          },
+          "elements": [],
+          "name": "Element 1735831924100",
+          "oneClickMode": "off",
+          "placement": {
+            "height": 100,
+            "left": 0,
+            "rotation": 0,
+            "top": 0,
+            "width": 100
+          },
+          "type": "frame"
+        },
+        "showAdvancedTypes": true,
+        "tooltip": {
+          "disableForOneClick": false,
+          "mode": "single"
+        },
+        "zoomToContent": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {},
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": true,
+      "type": "canvas"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5c5c6f",
+            "mode": "fixed"
+          },
+          "displayName": "${__field.name}",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4. Very Large [$1.0M+]"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e76a6b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3. Large [$500K – $1.0M)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e98061",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2. Medium [$250K – $500K)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#eca464",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1. Small ($0 – $250K)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f1c967",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 12
+      },
+      "id": 116,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect coalesce(tam_category_family, '0. None') as label\n  , count(a.account_id) as ct\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\nGROUP BY 1\n\norder by 1 desc\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "label",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "ct",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Accounts by TAM (Family)",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5c5c6f",
+            "mode": "fixed"
+          },
+          "displayName": "${__field.name}",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1. Contracted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5f7fde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2. Open Pipeline"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9282e9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3. Prior Pipeline"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#c06bcb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4. Self-Serve Usage"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e76a6b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5. Free / Trial Usage"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e98061",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "6. Event Activity or Web Traffic"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#eca464",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "7. Opt-Ins"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f1c967",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 6,
+        "y": 12
+      },
+      "id": 56,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect replace(account_funnel_score_name, 'Campain', 'Campaign') as label\n  , count(a.account_id) as ct\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\nGROUP BY 1\n\norder by 1\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "label",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "ct",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Accounts by Account Funnel Rank",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5c5c6f",
+            "mode": "fixed"
+          },
+          "displayName": "${__field.name}",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Medium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#c06bcb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9282e9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Very Low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5f7fde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "High"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#df6985",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 12,
+        "y": 12
+      },
+      "id": 143,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect company_behavior_signal_marketing_ops as label\n  , count(a.account_id) as ct\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\nGROUP BY 1\n\norder by 1\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "label",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "ct",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "High": 0,
+              "Low": 2,
+              "Medium": 1,
+              "No Recent Activity": 4,
+              "Value": 5,
+              "Very Low": 3
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "title": "Accounts by Behavior Signal",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5c5c6f",
+            "mode": "fixed"
+          },
+          "displayName": "${__field.name}",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f1c967",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "High"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e98061",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Medium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#eca464",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 12
+      },
+      "id": 144,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sales_activity_pulse_marketing_ops as label\n  , count(a.account_id) as ct\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\nGROUP BY 1\n\norder by 1\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "label",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "ct",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "High": 0,
+              "Low": 2,
+              "Medium": 1,
+              "No Activity": 3
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "title": "Accounts by Sales Activity Pulse",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 53475,
+      "title": "Current Customers",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#9282e9",
+            "mode": "fixed"
+          },
+          "displayName": "Committed ARR",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 23
+      },
+      "id": 107,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\n\n\nselect sum(arr_curr) as val\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          },
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Attainment"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#5c5c6f",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e76a6b",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e98061",
+                      "value": 0.25
+                    },
+                    {
+                      "color": "#eca464",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "#f1c967",
+                      "value": 0.75
+                    },
+                    {
+                      "color": "#5f7fde",
+                      "value": 1
+                    },
+                    {
+                      "color": "#9282e9",
+                      "value": 1.25
+                    },
+                    {
+                      "color": "#c06bcb",
+                      "value": 1.5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 5,
+        "y": 23
+      },
+      "id": 157,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(consumption_weighted_last_month) as consumption\n  , sum(consumption_weighted_quota_last_month) as month_target\n  , sum(committed_mrr_last_month) as committed_mrr\n\n  , (sum(consumption_weighted_last_month_with_quota))::numeric / NULLIF(sum(committed_mrr_last_month), 0) as attain_month_target\n  , (sum(consumption_weighted_last_month_with_committed_mrr))::numeric / NULLIF(sum(committed_mrr_last_month), 0) as attain_committed_mrr\n\n  , TO_CHAR(current_date - interval '1 month', 'Month') || ' Consumption' as consumption_label\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n--where account_funnel_score_number = 1",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "applyTo": {
+              "id": "byName",
+              "options": "consumption"
+            },
+            "configRefId": "A",
+            "mappings": [
+              {
+                "fieldName": "consumption_label",
+                "handlerKey": "displayName"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "attain_committed_mrr": true,
+              "attain_month_target": true,
+              "attain_quota": true,
+              "committed_mrr": true,
+              "consumption": false,
+              "month_target": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "actual": "Consumed",
+              "attain": "Attainment",
+              "attain_committed_mrr": "Attainment",
+              "attain_month_target": "Attainment",
+              "attain_quota": "Attainment",
+              "committed_mrr": "Committed MRR",
+              "consumption": "",
+              "consumption_quota_mrr": "MRR Quota",
+              "consumption_weighted_actual_ttl_last_3_months": "MRR Consumed",
+              "consumption_weighted_quota_ttl_last_3_months": "MRR Consumed",
+              "month_target": "Month Target",
+              "quota": "Month Target",
+              "quota_mrr": "Total Quota",
+              "total_mrr": "Total MRR"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          },
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Attainment"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#5c5c6f",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e76a6b",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e98061",
+                      "value": 0.25
+                    },
+                    {
+                      "color": "#eca464",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "#f1c967",
+                      "value": 0.75
+                    },
+                    {
+                      "color": "#5f7fde",
+                      "value": 1
+                    },
+                    {
+                      "color": "#9282e9",
+                      "value": 1.25
+                    },
+                    {
+                      "color": "#c06bcb",
+                      "value": 1.5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 7,
+        "y": 23
+      },
+      "id": 119,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(consumption_weighted_last_month) as consumption\n  , sum(consumption_weighted_quota_last_month) as month_target\n  , sum(committed_mrr_last_month) as committed_mrr\n\n  , (sum(consumption_weighted_last_month_with_quota))::numeric / NULLIF(sum(consumption_weighted_quota_last_month), 0) as attain_month_target\n  , (sum(consumption_weighted_last_month_with_committed_mrr))::numeric / NULLIF(sum(committed_mrr_last_month), 0) as attain_committed_mrr\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n--where account_funnel_score_number = 1",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "attain_committed_mrr": true,
+              "attain_quota": true,
+              "committed_mrr": true,
+              "consumption": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "actual": "Consumed",
+              "attain": "Attainment",
+              "attain_committed_mrr": "Attainment",
+              "attain_month_target": "Attainment",
+              "attain_quota": "Attainment",
+              "committed_mrr": "Committed MRR",
+              "consumption": "Consumed",
+              "consumption_quota_mrr": "MRR Quota",
+              "consumption_weighted_actual_ttl_last_3_months": "MRR Consumed",
+              "consumption_weighted_quota_ttl_last_3_months": "MRR Consumed",
+              "month_target": "Month Target",
+              "quota": "Month Target",
+              "quota_mrr": "Total Quota",
+              "total_mrr": "Total MRR"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          },
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Attainment"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#5c5c6f",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e76a6b",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e98061",
+                      "value": 0.25
+                    },
+                    {
+                      "color": "#eca464",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "#f1c967",
+                      "value": 0.75
+                    },
+                    {
+                      "color": "#5f7fde",
+                      "value": 1
+                    },
+                    {
+                      "color": "#9282e9",
+                      "value": 1.25
+                    },
+                    {
+                      "color": "#c06bcb",
+                      "value": 1.5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 11,
+        "y": 23
+      },
+      "id": 158,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(consumption_weighted_projected_current_month) as consumption\n  , sum(consumption_weighted_quota_current_month) as month_target\n  , sum(committed_mrr_current_month) as committed_mrr\n\n  , (sum(consumption_weighted_projected_current_month_with_quota))::numeric / NULLIF(sum(committed_mrr_current_month), 0) as attain_month_target\n  , (sum(consumption_weighted_projected_current_month_with_committed_mrr))::numeric / NULLIF(sum(committed_mrr_current_month), 0) as attain_committed_mrr\n\n  , TO_CHAR(current_date, 'Month') || ' Proj. Consumption' as consumption_label\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n--where account_funnel_score_number = 1",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "applyTo": {
+              "id": "byName",
+              "options": "consumption"
+            },
+            "configRefId": "A",
+            "mappings": [
+              {
+                "fieldName": "consumption_label",
+                "handlerKey": "displayName"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "attain_committed_mrr": true,
+              "attain_month_target": true,
+              "attain_quota": true,
+              "committed_mrr": true,
+              "consumption": false,
+              "month_target": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "actual": "Consumed",
+              "attain": "Attainment",
+              "attain_committed_mrr": "Attainment",
+              "attain_month_target": "Attainment",
+              "attain_quota": "Attainment",
+              "committed_mrr": "Committed MRR",
+              "consumption": "",
+              "consumption_quota_mrr": "MRR Quota",
+              "consumption_weighted_actual_ttl_last_3_months": "MRR Consumed",
+              "consumption_weighted_quota_ttl_last_3_months": "MRR Consumed",
+              "month_target": "Month Target",
+              "quota": "Month Target",
+              "quota_mrr": "Total Quota",
+              "total_mrr": "Total MRR"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          },
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Attainment"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#5c5c6f",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e76a6b",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e98061",
+                      "value": 0.25
+                    },
+                    {
+                      "color": "#eca464",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "#f1c967",
+                      "value": 0.75
+                    },
+                    {
+                      "color": "#5f7fde",
+                      "value": 1
+                    },
+                    {
+                      "color": "#9282e9",
+                      "value": 1.25
+                    },
+                    {
+                      "color": "#c06bcb",
+                      "value": 1.5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 13,
+        "y": 23
+      },
+      "id": 159,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(consumption_weighted_projected_current_month) as consumption\n  , sum(consumption_weighted_quota_current_month) as month_target\n  , sum(committed_mrr_current_month) as committed_mrr\n\n  , (sum(consumption_weighted_projected_current_month_with_quota))::numeric / NULLIF(sum(consumption_weighted_quota_current_month), 0) as attain_month_target\n  , (sum(consumption_weighted_projected_current_month_with_committed_mrr))::numeric / NULLIF(sum(committed_mrr_current_month), 0) as attain_committed_mrr\n\n  , TO_CHAR(current_date, 'Month') || ' Proj. Consumption' as consumption_label\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n--where account_funnel_score_number = 1",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "applyTo": {
+              "id": "byName",
+              "options": "consumption"
+            },
+            "configRefId": "A",
+            "mappings": [
+              {
+                "fieldName": "consumption_label",
+                "handlerKey": "displayName"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "attain_committed_mrr": true,
+              "attain_month_target": false,
+              "attain_quota": true,
+              "committed_mrr": true,
+              "consumption": true,
+              "consumption_label": true,
+              "month_target": false
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "actual": "Consumed",
+              "attain": "Attainment",
+              "attain_committed_mrr": "Attainment",
+              "attain_month_target": "Attainment",
+              "attain_quota": "Attainment",
+              "committed_mrr": "Committed MRR",
+              "consumption": "",
+              "consumption_quota_mrr": "MRR Quota",
+              "consumption_weighted_actual_ttl_last_3_months": "MRR Consumed",
+              "consumption_weighted_quota_ttl_last_3_months": "MRR Consumed",
+              "month_target": "Month Target",
+              "quota": "Month Target",
+              "quota_mrr": "Total Quota",
+              "total_mrr": "Total MRR"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "value": null,
+                "color": "#9282e900"
+              }
+            ]
+          },
+          "unit": "locale",
+          "min": 0,
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "label\\status"
+            },
+            "properties": []
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Using Competitor"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "percentage",
+                  "steps": [
+                    {
+                      "color": "#E76A6B00",
+                      "value": null
+                    },
+                    {
+                      "color": "#E76A6B1a",
+                      "value": 1e-05
+                    },
+                    {
+                      "color": "#E76A6B33",
+                      "value": 20
+                    },
+                    {
+                      "color": "#E76A6B4d",
+                      "value": 30
+                    },
+                    {
+                      "color": "#E76A6B66",
+                      "value": 40
+                    },
+                    {
+                      "color": "#E76A6B80",
+                      "value": 50
+                    },
+                    {
+                      "color": "#E76A6B99",
+                      "value": 60
+                    },
+                    {
+                      "color": "#E76A6Bb3",
+                      "value": 70
+                    },
+                    {
+                      "color": "#E76A6Bcc",
+                      "value": 80
+                    },
+                    {
+                      "color": "#E76A6Be6",
+                      "value": 90
+                    },
+                    {
+                      "color": "#E76A6B",
+                      "value": 100
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Currently Using"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "percentage",
+                  "steps": [
+                    {
+                      "color": "#5F7FDE00",
+                      "value": null
+                    },
+                    {
+                      "color": "#5F7FDE1a",
+                      "value": 1e-05
+                    },
+                    {
+                      "color": "#5F7FDE33",
+                      "value": 20
+                    },
+                    {
+                      "color": "#5F7FDE4d",
+                      "value": 30
+                    },
+                    {
+                      "color": "#5F7FDE66",
+                      "value": 40
+                    },
+                    {
+                      "color": "#5F7FDE80",
+                      "value": 50
+                    },
+                    {
+                      "color": "#5F7FDE99",
+                      "value": 60
+                    },
+                    {
+                      "color": "#5F7FDEb3",
+                      "value": 70
+                    },
+                    {
+                      "color": "#5F7FDEcc",
+                      "value": 80
+                    },
+                    {
+                      "color": "#5F7FDEe6",
+                      "value": 90
+                    },
+                    {
+                      "color": "#5F7FDE",
+                      "value": 100
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Not Using"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "percentage",
+                  "steps": [
+                    {
+                      "color": "#5C5C6F00",
+                      "value": null
+                    },
+                    {
+                      "color": "#5C5C6F1a",
+                      "value": 1e-05
+                    },
+                    {
+                      "color": "#5C5C6F33",
+                      "value": 20
+                    },
+                    {
+                      "color": "#5C5C6F4d",
+                      "value": 30
+                    },
+                    {
+                      "color": "#5C5C6F66",
+                      "value": 40
+                    },
+                    {
+                      "color": "#5C5C6F80",
+                      "value": 50
+                    },
+                    {
+                      "color": "#5C5C6F99",
+                      "value": 60
+                    },
+                    {
+                      "color": "#5C5C6Fb3",
+                      "value": 70
+                    },
+                    {
+                      "color": "#5C5C6Fcc",
+                      "value": 80
+                    },
+                    {
+                      "color": "#5C5C6Fe6",
+                      "value": 90
+                    },
+                    {
+                      "color": "#5C5C6F",
+                      "value": 100
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used in Last 3 Months"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "percentage",
+                  "steps": [
+                    {
+                      "color": "#ECA46400",
+                      "value": null
+                    },
+                    {
+                      "color": "#ECA4641a",
+                      "value": 1e-05
+                    },
+                    {
+                      "color": "#ECA46433",
+                      "value": 20
+                    },
+                    {
+                      "color": "#ECA4644d",
+                      "value": 30
+                    },
+                    {
+                      "color": "#ECA46466",
+                      "value": 40
+                    },
+                    {
+                      "color": "#ECA46480",
+                      "value": 50
+                    },
+                    {
+                      "color": "#ECA46499",
+                      "value": 60
+                    },
+                    {
+                      "color": "#ECA464b3",
+                      "value": 70
+                    },
+                    {
+                      "color": "#ECA464cc",
+                      "value": 80
+                    },
+                    {
+                      "color": "#ECA464e6",
+                      "value": 90
+                    },
+                    {
+                      "color": "#ECA464",
+                      "value": 100
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Using Competitor"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "percentage",
+                  "steps": [
+                    {
+                      "color": "#ECA46400",
+                      "value": null
+                    },
+                    {
+                      "color": "#ECA4641a",
+                      "value": 10
+                    },
+                    {
+                      "color": "#ECA46433",
+                      "value": 20
+                    },
+                    {
+                      "color": "#ECA4644d",
+                      "value": 30
+                    },
+                    {
+                      "color": "#ECA46466",
+                      "value": 40
+                    },
+                    {
+                      "color": "#ECA46480",
+                      "value": 50
+                    },
+                    {
+                      "color": "#ECA46499",
+                      "value": 60
+                    },
+                    {
+                      "color": "#ECA464b3",
+                      "value": 70
+                    },
+                    {
+                      "color": "#ECA464cc",
+                      "value": 80
+                    },
+                    {
+                      "color": "#ECA464e6",
+                      "value": 90
+                    },
+                    {
+                      "color": "#ECA464",
+                      "value": 100
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 7,
+        "x": 17,
+        "y": 23
+      },
+      "id": 162,
+      "options": {
+        "toolbar": {
+          "export": false,
+          "alignment": "left"
+        },
+        "tables": [
+          {
+            "actionsColumnConfig": {
+              "alignment": "start",
+              "fontSize": "md",
+              "label": "",
+              "width": {
+                "auto": false,
+                "value": 100
+              }
+            },
+            "addRow": {
+              "enabled": false,
+              "permission": {
+                "mode": "",
+                "userRole": []
+              },
+              "request": {
+                "datasource": "",
+                "payload": {}
+              }
+            },
+            "deleteRow": {
+              "enabled": false,
+              "permission": {
+                "mode": "",
+                "userRole": []
+              },
+              "request": {
+                "datasource": "",
+                "payload": {}
+              }
+            },
+            "expanded": false,
+            "items": [
+              {
+                "aggregation": "none",
+                "appearance": {
+                  "alignment": "start",
+                  "background": {
+                    "applyToRow": false
+                  },
+                  "colors": {},
+                  "header": {
+                    "fontSize": "md"
+                  },
+                  "width": {
+                    "auto": true,
+                    "min": 20,
+                    "value": 100
+                  },
+                  "wrap": true
+                },
+                "columnTooltip": "",
+                "edit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false,
+                  "permission": {
+                    "mode": "",
+                    "userRole": []
+                  }
+                },
+                "enabled": true,
+                "field": {
+                  "name": "label\\status",
+                  "source": 0
+                },
+                "filter": {
+                  "enabled": false,
+                  "mode": "client",
+                  "variable": ""
+                },
+                "footer": [],
+                "gauge": {
+                  "mode": "basic",
+                  "valueDisplayMode": "text",
+                  "valueSize": 14
+                },
+                "group": false,
+                "label": "",
+                "newRowEdit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false
+                },
+                "objectId": "",
+                "pin": "left",
+                "preformattedStyle": false,
+                "scale": "auto",
+                "showingRows": 20,
+                "sort": {
+                  "descFirst": false,
+                  "enabled": false
+                },
+                "type": "auto"
+              },
+              {
+                "aggregation": "none",
+                "appearance": {
+                  "alignment": "end",
+                  "background": {
+                    "applyToRow": false
+                  },
+                  "colors": {},
+                  "header": {
+                    "fontSize": "md"
+                  },
+                  "width": {
+                    "auto": true,
+                    "min": 20,
+                    "value": 100
+                  },
+                  "wrap": true
+                },
+                "columnTooltip": "",
+                "edit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false,
+                  "permission": {
+                    "mode": "",
+                    "userRole": []
+                  }
+                },
+                "enabled": true,
+                "field": {
+                  "name": "🔵 Currently Using",
+                  "source": 0
+                },
+                "filter": {
+                  "enabled": false,
+                  "mode": "client",
+                  "variable": ""
+                },
+                "footer": [],
+                "gauge": {
+                  "mode": "basic",
+                  "valueDisplayMode": "text",
+                  "valueSize": 14
+                },
+                "group": false,
+                "label": "",
+                "newRowEdit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false
+                },
+                "objectId": "",
+                "pin": "",
+                "preformattedStyle": false,
+                "scale": "auto",
+                "showingRows": 20,
+                "sort": {
+                  "descFirst": false,
+                  "enabled": false
+                },
+                "type": "coloredBackground"
+              },
+              {
+                "aggregation": "none",
+                "appearance": {
+                  "alignment": "end",
+                  "background": {
+                    "applyToRow": false
+                  },
+                  "colors": {},
+                  "header": {
+                    "fontSize": "md"
+                  },
+                  "width": {
+                    "auto": true,
+                    "min": 20,
+                    "value": 100
+                  },
+                  "wrap": true
+                },
+                "columnTooltip": "",
+                "edit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false,
+                  "permission": {
+                    "mode": "",
+                    "userRole": []
+                  }
+                },
+                "enabled": true,
+                "field": {
+                  "name": "🟠 Used in Last 3 Months",
+                  "source": 0
+                },
+                "filter": {
+                  "enabled": false,
+                  "mode": "client",
+                  "variable": ""
+                },
+                "footer": [],
+                "gauge": {
+                  "mode": "basic",
+                  "valueDisplayMode": "text",
+                  "valueSize": 14
+                },
+                "group": false,
+                "label": "",
+                "newRowEdit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false
+                },
+                "objectId": "",
+                "pin": "",
+                "preformattedStyle": false,
+                "scale": "auto",
+                "showingRows": 20,
+                "sort": {
+                  "descFirst": false,
+                  "enabled": false
+                },
+                "type": "coloredBackground"
+              },
+              {
+                "aggregation": "none",
+                "appearance": {
+                  "alignment": "end",
+                  "background": {
+                    "applyToRow": false
+                  },
+                  "colors": {},
+                  "header": {
+                    "fontSize": "md"
+                  },
+                  "width": {
+                    "auto": true,
+                    "min": 20,
+                    "value": 100
+                  },
+                  "wrap": true
+                },
+                "columnTooltip": "",
+                "edit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false,
+                  "permission": {
+                    "mode": "",
+                    "userRole": []
+                  }
+                },
+                "enabled": true,
+                "field": {
+                  "name": "Not Using",
+                  "source": 0
+                },
+                "filter": {
+                  "enabled": false,
+                  "mode": "client",
+                  "variable": ""
+                },
+                "footer": [],
+                "gauge": {
+                  "mode": "basic",
+                  "valueDisplayMode": "text",
+                  "valueSize": 14
+                },
+                "group": false,
+                "label": "",
+                "newRowEdit": {
+                  "editor": {
+                    "type": "string"
+                  },
+                  "enabled": false
+                },
+                "objectId": "",
+                "pin": "",
+                "preformattedStyle": false,
+                "scale": "auto",
+                "showingRows": 20,
+                "sort": {
+                  "descFirst": false,
+                  "enabled": false
+                },
+                "type": "coloredBackground"
+              }
+            ],
+            "name": "Waterfall",
+            "pagination": {
+              "defaultPageSize": 10,
+              "enabled": false,
+              "mode": "client"
+            },
+            "rowHighlight": {
+              "backgroundColor": "transparent",
+              "columnId": "",
+              "enabled": false,
+              "scrollTo": "",
+              "smooth": false,
+              "variable": ""
+            },
+            "showHeader": true,
+            "update": {
+              "datasource": "",
+              "payload": {}
+            }
+          }
+        ],
+        "nestedObjects": []
+      },
+      "pluginVersion": "2.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\n, accounts_cte as (\n  select a.account_id\n    , uses_visualization_status\n    , uses_metrics_status\n    , uses_logs_status\n    , uses_traces_status\n    , uses_profiles_status\n    , uses_k6_status\n    , uses_synthetics_status\n    , uses_frontend_observability_status\n    , uses_application_observability_status\n    , uses_kubernetes_monitoring_status\n    , uses_irm_status\n    , uses_database_observability_status\n    , uses_grafana_assistant_status\n\n  from territory_nav.revops_reporting_territory_navigator_account_details as a\n\n  inner join account_filter_cte as f on f.account_id = a.account_id\n\n  where account_funnel_score_number = 1 --contracted only\n)\n\n, visualization_usage_cte as (\n  select 'Visualization' as label\n    , 1 as sort\n    , uses_visualization_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, metrics_usage_cte as (\n  select 'Metrics' as label\n    , 2 as sort\n    , uses_metrics_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, logs_usage_cte as (\n  select 'Logs' as label\n    , 3 as sort\n    , uses_logs_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, traces_usage_cte as (\n  select 'Traces' as label\n    , 4 as sort\n    , uses_traces_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, profiles_usage_cte as (\n  select 'Profiles' as label\n    , 5 as sort\n    , uses_profiles_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, k6_usage_cte as (\n  select 'K6' as label\n    , 6 as sort\n    , uses_k6_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, synthetics_usage_cte as (\n  select 'Synthetics' as label\n    , 7 as sort\n    , uses_synthetics_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, frontend_observability_usage_cte as (\n  select 'FE O11y' as label\n    , 8 as sort\n    , uses_frontend_observability_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, application_observability_usage_cte as (\n  select 'App O11y' as label\n    , 9 as sort\n    , uses_application_observability_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, kubernetes_monitoring_usage_cte as (\n  select 'K8s Monitoring' as label\n    , 10 as sort\n    , uses_kubernetes_monitoring_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, irm_usage_cte as (\n  select 'IRM' as label\n    , 11 as sort\n    , uses_irm_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, database_observability_usage_cte as (\n  select 'DB O11y' as label\n    , 12 as sort\n    , uses_database_observability_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, grafana_assistant_usage_cte as (\n  select 'Grafana Assistant' as label\n    , 13 as sort\n    , uses_grafana_assistant_status as status\n    , count(distinct(account_id)) as ct\n\n  from accounts_cte\n\n  GROUP BY 1, 2, 3\n)\n\n, union_cte as (\n  select * from visualization_usage_cte\n\n  union all\n\n  select * from metrics_usage_cte\n\n  union all\n\n  select * from logs_usage_cte\n\n  union all\n\n  select * from traces_usage_cte\n\n  union all\n\n  select * from profiles_usage_cte\n\n  union all\n\n  select * from k6_usage_cte\n\n  union all\n\n  select * from synthetics_usage_cte\n\n  union all\n\n  select * from frontend_observability_usage_cte\n\n  union all\n\n  select * from application_observability_usage_cte\n\n  union all\n\n  select * from kubernetes_monitoring_usage_cte\n\n  union all\n\n  select * from irm_usage_cte\n\n  union all\n\n  select * from database_observability_usage_cte\n\n  union all\n\n  select * from grafana_assistant_usage_cte\n)\n\n, map_labels_cte as (\n  select label\n    , sort\n\n  from union_cte\n\n  GROUP BY 1, 2\n)\n\n, map_statuses_cte as (\n  select distinct(uses_visualization_status) as status\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  GROUP BY 1\n)\n\n\n\nselect\n  map_labels_cte.label\n  , CASE WHEN map_statuses_cte.status = '' THEN 'Not Using' ELSE map_statuses_cte.status END as status\n  , coalesce(union_cte.ct, 0) as ct\n\nfrom map_labels_cte\nCROSS JOIN map_statuses_cte\n\nleft join union_cte on union_cte.label = map_labels_cte.label\n  and union_cte.status = map_statuses_cte.status\n\norder by map_labels_cte.sort, map_labels_cte.label, map_statuses_cte.status\n\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "status",
+            "rowField": "label",
+            "valueField": "ct"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "sort": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Not Using": 3,
+              "label\\status": 0,
+              "🔵 Currently Using": 1,
+              "🟠 Used in Last 3 Months": 2
+            },
+            "renameByName": {
+              "label\\status": "Product",
+              "🔵 Currently Using": "Currently Using",
+              "🟠 Used in Last 3 Months": "Used in Last 3 Months, Not Currently Using"
+            }
+          }
+        }
+      ],
+      "title": "Product Usage Waterfall",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "volkovlabs-table-panel"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          },
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Attainment"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#5c5c6f",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e76a6b",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e98061",
+                      "value": 0.25
+                    },
+                    {
+                      "color": "#eca464",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "#f1c967",
+                      "value": 0.75
+                    },
+                    {
+                      "color": "#5f7fde",
+                      "value": 1
+                    },
+                    {
+                      "color": "#9282e9",
+                      "value": 1.25
+                    },
+                    {
+                      "color": "#c06bcb",
+                      "value": 1.5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 7,
+        "y": 26
+      },
+      "id": 156,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(consumption_weighted_last_month) as consumption\n  , sum(consumption_weighted_quota_last_month) as month_target\n  , sum(committed_mrr_last_month) as committed_mrr\n\n  , (sum(consumption_weighted_last_month_with_quota))::numeric / NULLIF(sum(committed_mrr_last_month), 0) as attain_month_target\n  , (sum(consumption_weighted_last_month_with_committed_mrr))::numeric / NULLIF(sum(committed_mrr_last_month), 0) as attain_committed_mrr\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n--where account_funnel_score_number = 1",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "attain_committed_mrr": false,
+              "attain_month_target": true,
+              "attain_quota": true,
+              "committed_mrr": false,
+              "consumption": true,
+              "month_target": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "actual": "Consumed",
+              "attain": "Attainment",
+              "attain_committed_mrr": "Attainment",
+              "attain_month_target": "Attainment",
+              "attain_quota": "Attainment",
+              "committed_mrr": "Committed MRR",
+              "consumption": "Consumed",
+              "consumption_quota_mrr": "MRR Quota",
+              "consumption_weighted_actual_ttl_last_3_months": "MRR Consumed",
+              "consumption_weighted_quota_ttl_last_3_months": "MRR Consumed",
+              "month_target": "Month Target",
+              "quota": "Month Target",
+              "quota_mrr": "Total Quota",
+              "total_mrr": "Total MRR"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          },
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Attainment"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#5c5c6f",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e76a6b",
+                      "value": 0
+                    },
+                    {
+                      "color": "#e98061",
+                      "value": 0.25
+                    },
+                    {
+                      "color": "#eca464",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "#f1c967",
+                      "value": 0.75
+                    },
+                    {
+                      "color": "#5f7fde",
+                      "value": 1
+                    },
+                    {
+                      "color": "#9282e9",
+                      "value": 1.25
+                    },
+                    {
+                      "color": "#c06bcb",
+                      "value": 1.5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 13,
+        "y": 26
+      },
+      "id": 160,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(consumption_weighted_projected_current_month) as consumption\n  , sum(consumption_weighted_quota_current_month) as month_target\n  , sum(committed_mrr_current_month) as committed_mrr\n\n  , (sum(consumption_weighted_projected_current_month_with_quota))::numeric / NULLIF(sum(committed_mrr_current_month), 0) as attain_month_target\n  , (sum(consumption_weighted_projected_current_month_with_committed_mrr))::numeric / NULLIF(sum(committed_mrr_current_month), 0) as attain_committed_mrr\n\n  , TO_CHAR(current_date, 'Month') || ' Proj. Consumption' as consumption_label\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n--where account_funnel_score_number = 1",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "applyTo": {
+              "id": "byName",
+              "options": "consumption"
+            },
+            "configRefId": "A",
+            "mappings": [
+              {
+                "fieldName": "consumption_label",
+                "handlerKey": "displayName"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "attain_committed_mrr": false,
+              "attain_month_target": true,
+              "attain_quota": true,
+              "committed_mrr": false,
+              "consumption": true,
+              "consumption_label": true,
+              "month_target": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "actual": "Consumed",
+              "attain": "Attainment",
+              "attain_committed_mrr": "Attainment",
+              "attain_month_target": "Attainment",
+              "attain_quota": "Attainment",
+              "committed_mrr": "Committed MRR",
+              "consumption": "",
+              "consumption_quota_mrr": "MRR Quota",
+              "consumption_weighted_actual_ttl_last_3_months": "MRR Consumed",
+              "consumption_weighted_quota_ttl_last_3_months": "MRR Consumed",
+              "month_target": "Month Target",
+              "quota": "Month Target",
+              "quota_mrr": "Total Quota",
+              "total_mrr": "Total MRR"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#9282e9",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 29
+      },
+      "id": 109,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\n\n\nselect sum(arr_cloud_curr) as val_cloud\n  , sum(arr_enterprise_curr) as val_enterprise\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details as a\n\ninner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "arr_curr_cloud": 0,
+              "arr_curr_enterprise": 1
+            },
+            "renameByName": {
+              "arr_curr_cloud": "Cloud ARR",
+              "arr_curr_enterprise": "Enterprise ARR",
+              "val_cloud": "Cloud ARR",
+              "val_enterprise": "Enterprise ARR"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5c5c6f",
+            "mode": "fixed"
+          },
+          "displayName": "${__field.name}",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "No Usage"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5c5c6f",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "(0%–25%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e76a6b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[25%–50%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e98061",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[50%–75%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#eca464",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[75%–100%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f1c967",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[100%–125%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5f7fde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[125%–150%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9282e9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "150%+"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#c06bcb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 5,
+        "y": 29
+      },
+      "id": 118,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\n, base_cte as (\n  select coalesce(consumption_committed_mrr_attainment_band_name_last_month, 'No Consumption_Quota') as label\n    , coalesce(consumption_committed_mrr_attainment_band_number_last_month, -1) as sort\n    , a.account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details as a\n\n  inner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n  where account_funnel_score_number = 1\n)\n\nselect label\n  , count(distinct(account_id)) as ct\n\nfrom base_cte\n\ngroup by sort, label\n\norder by sort, label",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "ct",
+                "handlerKey": "field.value"
+              },
+              {
+                "fieldName": "label",
+                "handlerKey": "field.name"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Attain of Committed MRR, Last Month",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#5c5c6f",
+            "mode": "fixed"
+          },
+          "displayName": "${__field.name}",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "No Usage"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5c5c6f",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "(0%–25%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e76a6b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[25%–50%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#e98061",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[50%–75%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#eca464",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[75%–100%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f1c967",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[100%–125%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5f7fde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "[125%–150%)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9282e9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "150%+"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#c06bcb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 11,
+        "y": 29
+      },
+      "id": 140,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\n, base_cte as (\n  select coalesce(consumption_committed_mrr_attainment_band_name_projected_current_month, 'No Consumption_Quota') as label\n    , coalesce(consumption_committed_mrr_attainment_band_number_projected_current_month, -1) as sort\n    , a.account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details as a\n\n  inner join account_filter_cte on account_filter_cte.account_id = a.account_id\n\n  where account_funnel_score_number = 1\n)\n\nselect label\n  , count(distinct(account_id)) as ct\n\nfrom base_cte\n\ngroup by sort, label\n\norder by sort, label",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "ct",
+                "handlerKey": "field.value"
+              },
+              {
+                "fieldName": "label",
+                "handlerKey": "field.name"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Proj Attain of Committed MRR, This Month",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "bargauge"
+    },
+    {
+      "datasource": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 4,
+        "x": 0,
+        "y": 33
+      },
+      "id": 117,
+      "options": {
+        "infinitePan": false,
+        "inlineEditing": true,
+        "panZoom": false,
+        "root": {
+          "background": {
+            "color": {
+              "fixed": "transparent"
+            }
+          },
+          "border": {
+            "color": {
+              "fixed": "dark-green"
+            }
+          },
+          "constraint": {
+            "horizontal": "left",
+            "vertical": "top"
+          },
+          "elements": [],
+          "name": "Element 1735831924100",
+          "oneClickMode": "off",
+          "placement": {
+            "height": 100,
+            "left": 0,
+            "rotation": 0,
+            "top": 0,
+            "width": 100
+          },
+          "type": "frame"
+        },
+        "showAdvancedTypes": true,
+        "tooltip": {
+          "disableForOneClick": false,
+          "mode": "single"
+        },
+        "zoomToContent": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {},
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": true,
+      "type": "canvas"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#df6985",
+            "mode": "fixed"
+          },
+          "noValue": "$0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Open Net RACV"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 34
+      },
+      "id": 110,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\nselect sum(net_racv_split) as val\n  , count(distinct(o.account_id)) as ct_accts \n\nfrom territory_nav.revops_reporting_opp_split as o\n\ninner join account_filter_cte on account_filter_cte.account_id = o.account_id\n\nwhere stage_number < 7\n  and close_date between '${__from:date}'::date and '${__to:date}'::date\n  and net_racv_ttl > 0\n\n",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "ct_accts": "Accts w/ Open Renewal",
+              "val": "Open Net RACV"
+            }
+          }
+        }
+      ],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 56275,
+      "title": "Opportunity Details",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": true,
+            "tooltip": {
+              "placement": "auto"
+            },
+            "wrapHeaderText": true
+          },
+          "fieldMinMax": false,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "account_id"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom.viz",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/FC/"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "account_name"
+            },
+            "properties": [
+              {
+                "id": "custom.minWidth",
+                "value": 200
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account in Salesforce",
+                    "url": "https://grafanalabs.lightning.force.com/lightning/r/Account/${__data.fields.account_id}/view"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account in Aardvark",
+                    "url": "https://bi.grafana-ops.net/d/a1b6b39a-149c-43a0-863c-83bf4d30449e/aardvark-v2-account-details?orgId=1&var-sfdc_account_id=${__data.fields.account_id}&var-account_org_ids=All&var-stacks=All"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account in Consumption Dashboard",
+                    "url": "https://bi.grafana-ops.net/d/ee9lb26snlk3kc/account-consumption?orgId=1&var-sfdc_account_id=${__data.fields.account_id}"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Calls with Account in Gong",
+                    "url": "https://us-53469.app.gong.io/conversations?workspace-id=740297503776772224&callSearch=%7B%22search%22%3A%7B%22type%22%3A%22And%22%2C%22filters%22%3A%5B%7B%22type%22%3A%22LeadCompanyOrAccount%22%2C%22name%22%3A%22${__data.fields.account_name}%22%7D%5D%7D%7D"
+                  },
+                  {
+                    "oneClick": false,
+                    "targetBlank": true,
+                    "title": "Open Account's Primary Org in Billing Dashboard",
+                    "url": "https://ops.grafana-ops.net/d/2OQseaNMz/billing-usage-internal?var-org_slug=${__data.fields.account_org_slug_sfdc}"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account's Primary Org in Admin Panel",
+                    "url": "https://admin.grafana.com/orgs/${__data.fields.account_org_id_sfdc}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "account_name_territory_parent"
+            },
+            "properties": [
+              {
+                "id": "custom.minWidth",
+                "value": 200
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account in Salesforce",
+                    "url": "https://grafanalabs.lightning.force.com/lightning/r/Account/${__data.fields.account_id_territory_parent}/view"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account in Aardvark",
+                    "url": "https://bi.grafana-ops.net/d/a1b6b39a-149c-43a0-863c-83bf4d30449e/aardvark-v2-account-details?orgId=1&var-sfdc_account_id=${__data.fields.account_id_territory_parent}&var-account_org_ids=All&var-stacks=All"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account in Consumption Dashboard",
+                    "url": "https://bi.grafana-ops.net/d/ee9lb26snlk3kc/account-consumption?orgId=1&var-sfdc_account_id=${__data.fields.account_id_territory_parent}"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Calls with Account in Gong",
+                    "url": "https://us-53469.app.gong.io/conversations?workspace-id=740297503776772224&callSearch=%7B%22search%22%3A%7B%22type%22%3A%22And%22%2C%22filters%22%3A%5B%7B%22type%22%3A%22LeadCompanyOrAccount%22%2C%22name%22%3A%22${__data.fields.account_name_territory_parent}%22%7D%5D%7D%7D"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account's Primary Org in Billing Dashboard",
+                    "url": "https://ops.grafana-ops.net/d/2OQseaNMz/billing-usage-internal?var-org_slug=${__data.fields.account_org_slug_sfdc_territory_parent}"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Open Account's Primary Org in Admin Panel",
+                    "url": "https://admin.grafana.com/orgs/${__data.fields.account_org_id_sfdc_territory_parent}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "account_id_territory_parent"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom.viz",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opp_id"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom.viz",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opp_name"
+            },
+            "properties": [
+              {
+                "id": "custom.minWidth",
+                "value": 200
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open Opportunity in Salesforce",
+                    "url": "https://grafanalabs.lightning.force.com/lightning/r/Opportunity/${__data.fields.opp_id}/view"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "fq_close_date"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "close_date"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "stage_name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "^7.*$": {
+                        "color": "#5f7fde",
+                        "index": 6
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "pattern": "^1.*$",
+                      "result": {
+                        "color": "text",
+                        "index": 0
+                      }
+                    },
+                    "type": "regex"
+                  },
+                  {
+                    "options": {
+                      "pattern": "^2.*$",
+                      "result": {
+                        "color": "#f1c967",
+                        "index": 1
+                      }
+                    },
+                    "type": "regex"
+                  },
+                  {
+                    "options": {
+                      "pattern": "^3.*$",
+                      "result": {
+                        "color": "#eca464",
+                        "index": 2
+                      }
+                    },
+                    "type": "regex"
+                  },
+                  {
+                    "options": {
+                      "pattern": "^4.*$",
+                      "result": {
+                        "color": "#e98061",
+                        "index": 3
+                      }
+                    },
+                    "type": "regex"
+                  },
+                  {
+                    "options": {
+                      "pattern": "^5.*$",
+                      "result": {
+                        "color": "#e76a6b",
+                        "index": 4
+                      }
+                    },
+                    "type": "regex"
+                  },
+                  {
+                    "options": {
+                      "pattern": "^6.*$",
+                      "result": {
+                        "color": "#c06bcb",
+                        "index": 5
+                      }
+                    },
+                    "type": "regex"
+                  },
+                  {
+                    "options": {
+                      "pattern": "^8.*$",
+                      "result": {
+                        "color": "#5c5c6f",
+                        "index": 7
+                      }
+                    },
+                    "type": "regex"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opp_type_qbr"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 180
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "Expansion": {
+                        "color": "#df6985",
+                        "index": 2
+                      },
+                      "Flat Renewal": {
+                        "color": "#e98061",
+                        "index": 3
+                      },
+                      "New (New Logo)": {
+                        "color": "#9282e9",
+                        "index": 0
+                      },
+                      "New (SS → Contracted)": {
+                        "color": "#c06bcb",
+                        "index": 1
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/\\$/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "locale"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "custom.width",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 134,
+      "options": {
+        "cellHeight": "sm",
+        "enablePagination": false,
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "All Data",
+          "editorMode": "code",
+          "enableStorageAPI": true,
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with account_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n)\n\n, opportunities_cte as (\n  select\n    o.account_id\n    , t.account_name\n    , t.account_id_territory_parent\n    , t.account_name_territory_parent\n    , opp_id\n    , opp_name\n    , opp_type_qbr\n    , stage_name\n    , fq_close_date\n    , close_date\n    , sum(net_nacv_split) as net_nacv\n    , sum(net_racv_split) as net_racv\n    , sum(net_tcv_split) as net_tcv\n    , sum(services_split) as services\n    , CASE WHEN is_cro_forecast THEN '✔︎' ELSE '' END as is_cro_forecast\n    , CASE WHEN is_vp_forecast THEN '✔︎' ELSE '' END as is_vp_forecast\n    , CASE WHEN is_rvp_forecast THEN '✔︎' ELSE '' END as is_rvp_forecast\n    , CASE WHEN is_rsd_forecast THEN '✔︎' ELSE '' END as is_rsd_forecast\n    , CASE WHEN is_ae_forecast THEN '✔︎' ELSE '' END as is_ae_forecast\n\n    , case when stage_number between 3 and 6 then 2\n      when stage_number = 2 then 1\n      else 0\n      end as stage_category\n\n  from territory_nav.revops_reporting_opp_split as o\n\n  inner join account_filter_cte as f on f.account_id = o.account_id\n\n  left join territory_nav.revops_reporting_territory_navigator_account_details as t on t.account_id = o.account_id\n\n  where close_date between '${__from:date}'::date and '${__to:date}'::date\n    and stage_number <= 6\n\n  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 18, 19, 20\n)\n\nselect *\n\nfrom opportunities_cte\n\norder by net_nacv desc, net_racv desc, net_tcv desc, services desc, opp_name, opp_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "label_has_ae_sdr_meeting": true,
+              "label_has_other_ae_sdr_engagement": true,
+              "stage_category": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "account_funnel_score_name": 12,
+              "account_id": 1,
+              "account_id_territory_parent": 3,
+              "account_industry_sub_industry_zoominfo": 42,
+              "account_mapped_sdr_name": 10,
+              "account_name": 2,
+              "account_name_territory_parent": 4,
+              "account_owner_name": 9,
+              "account_owner_region": 5,
+              "account_owner_rsd_region": 7,
+              "account_owner_rvp_region": 6,
+              "account_owner_segment": 8,
+              "arr_cloud_curr": 32,
+              "arr_curr": 31,
+              "arr_enterprise_curr": 33,
+              "close_date_next_renewal": 28,
+              "company_behavior_signal_description_marketing_ops": 14,
+              "company_behavior_signal_marketing_ops": 13,
+              "consumption_attainment": 37,
+              "consumption_quota_mrr": 36,
+              "consumption_weighted_quota_ttl_last_3_months": 35,
+              "ct_cw": 25,
+              "ct_employees_devops_clay": 44,
+              "ct_open_renewal": 27,
+              "ct_qp": 23,
+              "employee_ct_territory_parent": 43,
+              "f0_": 0,
+              "has_ae_sdr_meeting_display": 39,
+              "has_other_ae_sdr_engagement_display": 40,
+              "is_territory_parent_one_hot": 49,
+              "latest_funding_round_clay": 45,
+              "marquee_list_clay_display": 47,
+              "months_to_close_date_next_renewal": 29,
+              "sales_activity_pulse_description_marketing_ops": 16,
+              "sales_activity_pulse_marketing_ops": 15,
+              "spacer_1": 11,
+              "spacer_3": 38,
+              "spacer_4": 41,
+              "spacer_5": 30,
+              "spacer_6": 21,
+              "spacer_7": 34,
+              "string_product_usage": 18,
+              "tam_category_family": 20,
+              "technology_list": 48,
+              "total_funding_amount_clay_family": 46,
+              "usage_type_name": 17,
+              "val_cw": 24,
+              "val_open_renewal": 26,
+              "val_qp": 22,
+              "warmth_rank_warmth_model": 19
+            },
+            "renameByName": {
+              "account_funnel_score_name": "Account Funnel Score",
+              "account_industry_sub_industry_zoominfo": "Industry / Sub-Industry (ZoomInfo)",
+              "account_mapped_sdr_name": "SDR",
+              "account_name": "Account",
+              "account_name_territory_parent": "Territory Parent Account",
+              "account_owner_name": "Account Owner",
+              "account_owner_region": "Region",
+              "account_owner_rsd_region": "RSD Region",
+              "account_owner_rvp_region": "RVP Region",
+              "account_owner_segment": "Segment",
+              "arr_cloud_curr": "Committed Cloud ARR",
+              "arr_curr": "Committed ARR",
+              "arr_enterprise_curr": "Committed Enterprise ARR",
+              "close_date": "Close Date",
+              "close_date_next_renewal": "Next Renewal",
+              "company_behavior_signal_description_marketing_ops": "Behavior Signal Description",
+              "company_behavior_signal_marketing_ops": "Behavior Signal",
+              "consumption_attainment": "Consumption Attainment, Last 3 Months",
+              "consumption_quota_mrr": "MRR Quota, Last 3 Months",
+              "consumption_weighted_quota_ttl_last_3_months": "MRR Consumed, Last 3 Months",
+              "ct_cw": "# Closed / Won",
+              "ct_employees_devops_clay": "DevOps Employees (Clay)",
+              "ct_open_renewal": "# Open Renewal",
+              "ct_qp": "# QP",
+              "employee_ct_territory_parent": "Employee Count (Family)",
+              "fq_close_date": "Fiscal Quarter",
+              "has_ae_sdr_meeting": "AE / SDR Meeting",
+              "has_ae_sdr_meeting_display": "AE / SDR Meeting, Last 90 Days",
+              "has_other_ae_sdr_engagement": "AE / SDR Msg / Call, Last 90 Days",
+              "has_other_ae_sdr_engagement_display": "AE / SDR Call / Msg, Last 90 Days",
+              "is_ae_forecast": "AE FC",
+              "is_cro_forecast": "CRO FC",
+              "is_rsd_forecast": "RSD FC",
+              "is_rvp_forecast": "RVP FC",
+              "is_territory_parent_one_hot": " ",
+              "is_vp_forecast": "VP FC",
+              "latest_funding_round_clay": "Latest Funding (Clay)",
+              "marketing_ops_company_behavior_signal": "Behavior Signal",
+              "marketing_ops_sales_activity_pulse": "Sales Activity Pulse",
+              "marketing_ops_sales_activity_pulse_description": "Sales Activity Pulse Description",
+              "marketing_ops_signal_description": "Behavior Signal Description",
+              "marquee_list_clay": "Marquee List (Clay)",
+              "marquee_list_clay_display": "Marquee List (Clay)",
+              "months_to_close_date_next_renewal": "Months to Next Renewal",
+              "net_nacv": "$ Net NACV",
+              "net_nacv_plus_services": "Net NACV + Services",
+              "net_racv": "$ Net RACV",
+              "net_tcv": "$ Net TCV",
+              "opp_name": "Opportunity Name",
+              "opp_type_qbr": "Opportunity Type",
+              "sales_activity_pulse_description_marketing_ops": "Sales Activity Pulse Description",
+              "sales_activity_pulse_marketing_ops": "Sales Activity Pulse",
+              "services": "$ Services",
+              "spacer_1": " ",
+              "spacer_2": " ",
+              "spacer_3": " ",
+              "spacer_4": " ",
+              "spacer_5": " ",
+              "spacer_6": " ",
+              "spacer_7": " ",
+              "stage_name": "Stage",
+              "string_product_usage": "Products in Use",
+              "tam_category_family": "TAM Category (Family)",
+              "technology_list": "Technologies (Clay, HG Data)",
+              "total_funding_amount_clay_family": "Total Funding (Family) (Clay)",
+              "usage_type_name": "Product Usage Type",
+              "val_cw": "$ Closed / Won",
+              "val_open_renewal": "$ Open Renewal",
+              "val_qp": "$ QP",
+              "warmth_rank_warmth_model": "PtB Rank"
+            }
+          }
+        }
+      ],
+      "title": "Open Opportunities",
+      "description": "",
+      "links": [],
+      "transparent": false,
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 55837,
+      "title": "Appendix",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false,
+            "tooltip": {
+              "placement": "auto"
+            },
+            "wrapHeaderText": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Account Name"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Account Details Dashboard",
+                    "url": "d/a1b6b39a-149c-43a0-863c-83bf4d30449e/aardvark-v2-account-details?orgId=1&var-sfdc_account_id=${__data.fields.sfdc_account_id}"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Salesforce Account",
+                    "url": "https://grafanalabs.lightning.force.com/${__data.fields.sfdc_account_id}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 175
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Org Slug"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Org Details Dashboard",
+                    "url": "d/1eageR97z/org-details?orgId=1&var-org_slug=${__value.text}"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Admin Panel",
+                    "url": "https://admin.grafana.com/orgs/${__value.text}"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Billing/Usage Dashboard",
+                    "url": "https://ops.grafana-ops.net/d/2OQseaNMz/billing-usage-current?orgId=1&var-org_slug=${__value.text}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Org Type"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "Cloud Advanced": {
+                        "color": "#e76a6b",
+                        "index": 4
+                      },
+                      "Enterprise Self-Hosted": {
+                        "color": "#e76a6b",
+                        "index": 5
+                      },
+                      "Other (Legacy Orgs)": {
+                        "color": "#5c5c6f",
+                        "index": 7
+                      },
+                      "Sales-led Trial": {
+                        "color": "#c06bcb",
+                        "index": 6
+                      },
+                      "Self-Serve Advanced": {
+                        "color": "#eca464",
+                        "index": 3
+                      },
+                      "Self-Serve Free": {
+                        "color": "#f1c967",
+                        "index": 1
+                      },
+                      "Self-Serve Free (Inactive)": {
+                        "color": "#5c5c6f",
+                        "index": 8
+                      },
+                      "Self-Serve Pro": {
+                        "color": "#eca464",
+                        "index": 2
+                      },
+                      "Self-Serve Trial": {
+                        "color": "#5c5c6f33",
+                        "index": 0
+                      },
+                      "Self-Serve Trial (Inactive)": {
+                        "color": "#5c5c6f",
+                        "index": 9
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "transparent",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 175
+              },
+              {
+                "id": "custom.minWidth",
+                "value": 175
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Funnel Stage"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "Customer": {
+                        "color": "semi-dark-purple",
+                        "index": 0
+                      },
+                      "Prospect: No Opt-ins": {
+                        "color": "#5c5c6f",
+                        "index": 6
+                      },
+                      "Prospect: Open Pipe": {
+                        "color": "#c06bcb",
+                        "index": 1
+                      },
+                      "Prospect: Opt-ins": {
+                        "color": "super-light-blue",
+                        "index": 5
+                      },
+                      "Prospect: Prior Pipe": {
+                        "color": "#c06bcb",
+                        "index": 2
+                      },
+                      "Prospect: SS Free/Trial": {
+                        "color": "super-light-blue",
+                        "index": 4
+                      },
+                      "Prospect: SS Paid": {
+                        "color": "#5f7fde",
+                        "index": 3
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 175
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "custom.minWidth",
+                "value": 175
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Sales Plays"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "left"
+              },
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PtB Rank"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "A": {
+                        "color": "#e76a6b",
+                        "index": 0
+                      },
+                      "B": {
+                        "color": "#eca464",
+                        "index": 1
+                      },
+                      "C": {
+                        "color": "#f1c967",
+                        "index": 2
+                      },
+                      "Undefined": {
+                        "color": "#5c5c6f",
+                        "index": 3
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "arr"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "currencyUSD"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge",
+                  "valueDisplayMode": "text"
+                }
+              },
+              {
+                "id": "max",
+                "value": 200000
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*Billable.*/"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "unit",
+                "value": "locale"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": 0
+                    },
+                    {
+                      "color": "blue",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Datasources"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "arr_sparkline_values"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "dynamicHeight": false,
+                  "type": "markdown"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 250
+              },
+              {
+                "id": "custom.minWidth",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hm_sparkline_values"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "markdown"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 250
+              },
+              {
+                "id": "custom.minWidth",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*Δ.*/"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "text",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "from": 1e-06,
+                      "result": {
+                        "color": "green",
+                        "index": 1
+                      }
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "result": {
+                        "color": "red",
+                        "index": 2
+                      },
+                      "to": 1e-06
+                    },
+                    "type": "range"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^(?!.*MoM Users Δ).*Δ.*$"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sfdc_account_id"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom.viz",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "K8s Pricing"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "auto"
+              },
+              {
+                "id": "custom.width",
+                "value": 112
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 165,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "postgres-datasource"
+          },
+          "refId": "A",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "with\naccount_filter_cte as (\n  select account_id\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  where account_owner_id in (${filter_account_owner_id:singlequote})\n    and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})\n    and account_solutions_engineer_id in (${parameter_se_id:singlequote})\n    and account_observability_architect_id in (${parameter_oa_id:singlequote})\n    and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})\n    and is_account_assigned_to_ae_filter in (${parameter_is_account_assigned_to_ae:singlequote})\n    and is_territory_parent_filter in (${parameter_is_territory_parent:singlequote})\n    and account_billing_country in (${filter_billing_country:singlequote})\n    and account_billing_state_province in (${filter_billing_state_province:singlequote})\n    and consumption_committed_mrr_attainment_band_name_last_month in (${filter_attainment_band_last_month:singlequote})\n    and consumption_committed_mrr_attainment_band_name_projected_current_month in (${filter_projected_attainment_band_current_month:singlequote})\n),\n\n-- Use the materialized dbt model instead of rebuilding all the logic\nterritory_navigator_base as (\n    select *\n    from territory_nav.rpt_self_serve_territory_navigator_orgs\n)\n\nSELECT\n  tnb.sfdc_account_id,\n  tnb.sfdc_account_name,\n  tnb.org_slug,\n  tnb.org_type,\n  tnb.revops_account_funnel,\n  tnb.sales_plays,\n  tnb.warmth_rank_warmth_model,\n  tnb.last_activity_date,\n  tnb.arr,\n  tnb.mrr_delta,\n  tnb.billable_users,\n  tnb.billable_users_delta,\n  tnb.billable_series,\n  tnb.billable_series_delta,\n  tnb.billable_logs,\n  tnb.billable_logs_delta,\n  tnb.billable_traces,\n  tnb.billable_traces_delta,\n  tnb.billable_profiles,\n  tnb.billable_profiles_delta,\n  tnb.billable_k6_vuh,\n  tnb.billable_k6_vuh_delta,\n  tnb.billable_irm_users,\n  tnb.billable_irm_user_delta,\n  tnb.billable_app_o11y_host_hours,\n  tnb.billable_app_o11y_host_hours_delta,\n  tnb.billable_fe_o11y_sessions,\n  tnb.billable_fe_o11y_sessions_delta,\n  tnb.billable_sm_checks,\n  tnb.billable_sm_checks_delta,\n  tnb.hg_datasource_cnts,\n  tnb.integrations,\n  tnb.arr_sparkline_values,\n  tnb.hm_sparkline_values,\n  tnb.k8s_o11y_pricing_type\n\nFROM territory_navigator_base tnb\nINNER JOIN account_filter_cte \n  ON account_filter_cte.account_id = tnb.sfdc_account_id",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "account_mapped_sdr_id": true,
+              "account_mapped_sdr_name": true,
+              "account_observability_architect_id": true,
+              "account_observability_architect_manager_id": true,
+              "account_observability_architect_manager_name": true,
+              "account_observability_architect_name": true,
+              "account_owner_id": true,
+              "account_owner_name": true,
+              "account_owner_region": true,
+              "account_owner_rsd_region": true,
+              "account_owner_rvp_region": true,
+              "account_owner_segment": true,
+              "account_owner_seller_type": true,
+              "account_solutions_engineer_id": true,
+              "account_solutions_engineer_name": true,
+              "consumption_committed_mrr_attainment_band_name_last_month": true,
+              "consumption_committed_mrr_attainment_band_number_last_month": true,
+              "is_account_assigned_to_ae_filter": true,
+              "is_territory_parent_filter": true,
+              "sfdc_account_id": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "arr": 8,
+              "arr_sparkline_values": 10,
+              "billable_app_o11y_host_hours": 27,
+              "billable_app_o11y_host_hours_delta": 28,
+              "billable_fe_o11y_sessions": 29,
+              "billable_fe_o11y_sessions_delta": 30,
+              "billable_irm_user_delta": 26,
+              "billable_irm_users": 25,
+              "billable_k6_vuh": 23,
+              "billable_k6_vuh_delta": 24,
+              "billable_logs": 17,
+              "billable_logs_delta": 18,
+              "billable_profiles": 21,
+              "billable_profiles_delta": 22,
+              "billable_series": 13,
+              "billable_series_delta": 14,
+              "billable_sm_checks": 31,
+              "billable_sm_checks_delta": 32,
+              "billable_traces": 19,
+              "billable_traces_delta": 20,
+              "billable_users": 11,
+              "billable_users_delta": 12,
+              "hg_datasource_cnts": 33,
+              "hm_sparkline_values": 15,
+              "integrations": 34,
+              "k8s_o11y_pricing_type": 16,
+              "last_activity_date": 7,
+              "mrr_delta": 9,
+              "org_slug": 2,
+              "org_type": 3,
+              "revops_account_funnel": 4,
+              "sales_plays": 5,
+              "sfdc_account_id": 0,
+              "sfdc_account_name": 1,
+              "warmth_rank_warmth_model": 6
+            },
+            "renameByName": {
+              "arr": "Est. ARR $",
+              "arr_sparkline_values": "ARR Monthly Trend",
+              "billable_app_o11y_host_hours": "MTD Billable App O11y",
+              "billable_app_o11y_host_hours_delta": "MoM App O11y Δ",
+              "billable_fe_o11y_sessions": "MTD Billable FE O11y",
+              "billable_fe_o11y_sessions_delta": "MoM FE O11y Δ",
+              "billable_irm_user_delta": "MoM IRM Δ",
+              "billable_irm_users": "MTD Billable IRM",
+              "billable_k6_vuh": "MTD Billable k6 VUh",
+              "billable_k6_vuh_delta": "MoM k6 VUh Δ",
+              "billable_logs": "MTD Billable Logs",
+              "billable_logs_delta": "MoM Logs Δ",
+              "billable_profiles": "MTD Billable Profiles",
+              "billable_profiles_delta": "MoM Profiles Δ",
+              "billable_series": "MTD Billable Series",
+              "billable_series_delta": "MoM Series Δ",
+              "billable_sm_checks": "MTD Billable SM",
+              "billable_sm_checks_delta": "MoM SM Δ",
+              "billable_traces": "MTD Billable Traces",
+              "billable_traces_delta": "MoM Traces Δ",
+              "billable_users": "MTD Billable Users",
+              "billable_users_delta": "MoM Users Δ",
+              "hg_datasource_cnts": "Datasources",
+              "hl_usage_sparkline": "Logs Trend",
+              "hm_sparkline_values": "Metrics Monthly Trend",
+              "hm_usage_sparkline": "Metrics Trend",
+              "ht_usage_sparkline": "Traces Trend",
+              "integrations": "Integrations",
+              "k8s_o11y_pricing_type": "K8s Pricing",
+              "last_activity_date": "Last Activity",
+              "mrr_delta": "MoM ARR Δ",
+              "mrr_delta_1": "",
+              "mrr_sparkline": "MRR Trend",
+              "org_slug": "Org Slug",
+              "org_type": "Org Type",
+              "revops_account_funnel": "Funnel Stage",
+              "revops_account_funnel_step": "",
+              "sales_play": "Sales Play",
+              "sales_play_integration_potential": "Integration Potential",
+              "sales_plays": "Sales Plays",
+              "sfdc_account_name": "Account Name",
+              "warmth_rank_warmth_model": "PtB Rank"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Est. ARR $"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Org Details",
+      "description": "[Column Definitions & Sales Plays](https://docs.google.com/document/d/1wZg8a59SWanCmz1Y_JxpcX3r3Jm_grpe0hLzYS2vyCk/edit?tab=t.0#heading=h.km9ccgdbshp8)",
+      "links": [],
+      "transparent": false,
+      "type": "table"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 77
+      },
+      "id": 164,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<p>\n  Org Details courtesy of Self-Serve Analytics. Contact <a href=\"https://raintank-corp.slack.com/archives/C07NBDSCGJX\">#self-serve-analytics</a> for more information.\n</p>\n<p>\n  NOTE: The above panel may crash if too many accounts are selected in the filters at the top of the dashboard. If the panel crashes, try selecting fewer accounts (10k or fewer seems to work well).\n<p>\n\n",
+        "mode": "html"
+      },
+      "pluginVersion": "13.0.0-22641103213",
+      "targets": [],
+      "title": "",
+      "description": "",
+      "links": [],
+      "transparent": true,
+      "type": "text"
+    }
+  ],
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "type": "query",
+        "name": "filter_account_owner_l1_territory",
+        "label": "L1 Territory",
+        "current": {
+          "text": [
+            "APJ"
+          ],
+          "value": [
+            "APJ"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_owner_l1_territory)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\norder by 1",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_account_owner_l3_territory",
+        "label": "L3 Territory",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_owner_l3_territory)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_l1_territory in (${filter_account_owner_l1_territory:singlequote})\n\norder by 1",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_account_owner_l4_territory",
+        "label": "L4 Territory",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_owner_l4_territory)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_l1_territory in (${filter_account_owner_l1_territory:singlequote})\n  and account_owner_l3_territory in (${filter_account_owner_l3_territory:singlequote})\n\norder by 1",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_account_owner_l6_territory",
+        "label": "L6 Territory",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_owner_l6_territory)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_l1_territory in (${filter_account_owner_l1_territory:singlequote})\n  and account_owner_l3_territory in (${filter_account_owner_l3_territory:singlequote})\n  and account_owner_l4_territory in (${filter_account_owner_l4_territory:singlequote})\n\norder by 1",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_account_owner_segment",
+        "label": "Segment",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_owner_segment)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_l1_territory in (${filter_account_owner_l1_territory:singlequote})\n  and account_owner_l3_territory in (${filter_account_owner_l3_territory:singlequote})\n  and account_owner_l4_territory in (${filter_account_owner_l4_territory:singlequote})\n  and account_owner_l6_territory in (${filter_account_owner_l6_territory:singlequote})\n\norder by 1",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_account_owner_seller_type",
+        "label": "Seller Type",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_owner_seller_type)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_l1_territory in (${filter_account_owner_l1_territory:singlequote})\n  and account_owner_l3_territory in (${filter_account_owner_l3_territory:singlequote})\n  and account_owner_l4_territory in (${filter_account_owner_l4_territory:singlequote})\n  and account_owner_l6_territory in (${filter_account_owner_l6_territory:singlequote})\n  and account_owner_segment      in (${filter_account_owner_segment:singlequote})\n\norder by 1",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_account_owner_name",
+        "label": "Account Owner",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_owner_name)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_l1_territory in (${filter_account_owner_l1_territory:singlequote})\n  and account_owner_l3_territory in (${filter_account_owner_l3_territory:singlequote})\n  and account_owner_l4_territory in (${filter_account_owner_l4_territory:singlequote})\n  and account_owner_l6_territory in (${filter_account_owner_l6_territory:singlequote})\n  and account_owner_segment      in (${filter_account_owner_segment:singlequote})\n  and account_owner_seller_type  in (${filter_account_owner_seller_type:singlequote})\n\norder by 1",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_account_owner_id",
+        "label": "Account Owner ID",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 2,
+        "query": "select distinct(account_owner_id)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_l1_territory in (${filter_account_owner_l1_territory:singlequote})\n  and account_owner_l3_territory in (${filter_account_owner_l3_territory:singlequote})\n  and account_owner_l4_territory in (${filter_account_owner_l4_territory:singlequote})\n  and account_owner_l6_territory in (${filter_account_owner_l6_territory:singlequote})\n  and account_owner_segment      in (${filter_account_owner_segment:singlequote})\n  and account_owner_seller_type  in (${filter_account_owner_seller_type:singlequote})\n  and account_owner_name         in (${filter_account_owner_name:singlequote})\n\norder by 1\n",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_sdr_name",
+        "label": "SDR",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_mapped_sdr_name)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_sdr_id",
+        "label": "SDR ID",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 2,
+        "query": "select distinct(account_mapped_sdr_id)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})\n  and account_mapped_sdr_name in (${parameter_sdr_name:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_se_name",
+        "label": "SE",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_solutions_engineer_name)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_se_id",
+        "label": "SE ID",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 2,
+        "query": "select distinct(account_solutions_engineer_id)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})\n  and account_solutions_engineer_name in (${parameter_se_name:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_oa_manager_name",
+        "label": "OA Manager",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_observability_architect_manager_name)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_oa_manager_id",
+        "label": "OA Manager ID",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 2,
+        "query": "select distinct(account_observability_architect_manager_id)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})\n  and account_observability_architect_manager_name in (${parameter_oa_manager_name:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_oa_name",
+        "label": "OA",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_observability_architect_name)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})\n  and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_oa_id",
+        "label": "OA ID",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 2,
+        "query": "select distinct(account_observability_architect_id)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})\n  and account_observability_architect_name in (${parameter_oa_name:singlequote})\n  and account_observability_architect_manager_id in (${parameter_oa_manager_id:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_is_account_assigned_to_ae",
+        "label": "Assigned to AE",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(is_account_assigned_to_ae_filter)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})\n  and account_mapped_sdr_id in (${parameter_sdr_id:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "parameter_is_territory_parent",
+        "label": "Is Territory Parent Account",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(is_territory_parent_filter)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_billing_country",
+        "label": "Billing Country",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_billing_country)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_billing_state_province",
+        "label": "Billing State / Province",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "select distinct(account_billing_state_province)\n\nfrom territory_nav.revops_reporting_territory_navigator_account_details\n\nwhere account_owner_id in (${filter_account_owner_id:singlequote})\n  and account_billing_country in (${filter_billing_country:singlequote})",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_attainment_band_last_month",
+        "label": "Attainment Band (vs Committed MRR), Last Month",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "with base_cte as (\n  select\n    consumption_committed_mrr_attainment_band_name_last_month as label\n    , consumption_committed_mrr_attainment_band_number_last_month as sort\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  GROUP BY 1, 2\n)\n\nselect label\n\nfrom base_cte\n\norder by sort",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      },
+      {
+        "type": "query",
+        "name": "filter_projected_attainment_band_current_month",
+        "label": "Projected Attainment Band (vs Committed MRR), Current Month",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "multi": true,
+        "includeAll": true,
+        "allowCustomValue": false,
+        "definition": "",
+        "regex": "",
+        "sort": 0,
+        "refresh": 1,
+        "skipUrlSync": false,
+        "hide": 0,
+        "query": "with base_cte as (\n  select\n    consumption_committed_mrr_attainment_band_name_projected_current_month as label\n    , consumption_committed_mrr_attainment_band_number_projected_current_month as sort\n\n  from territory_nav.revops_reporting_territory_navigator_account_details\n\n  GROUP BY 1, 2\n)\n\nselect label\n\nfrom base_cte\n\norder by sort",
+        "datasource": {
+          "type": "postgres",
+          "uid": "postgres-datasource"
+        }
+      }
+    ]
+  },
+  "time": {
+    "from": "now/fy",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "hidden": false
+  },
+  "timezone": "utc",
+  "weekStart": "",
+  "preload": false
+}


### PR DESCRIPTION
Refresh the provisioned demo dashboards by renaming the CubeDS e-commerce examples to clearer slugs and adding the new territory navigator dashboard.

## Summary
- rename the two CubeDS e-commerce dashboard files and update their dashboard titles and UIDs
- update provisioning references so the Grafana home dashboard path and alert annotations keep pointing at the renamed full-model dashboard
- add the new `territory-navigator` provisioned dashboard

## Testing
- Not run (dashboard provisioning JSON and reference updates only)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Grafana provisioning JSON/UIDs and config references, with no runtime logic or data handling changes.
> 
> **Overview**
> Updates the provisioned CubeDS e-commerce demo dashboards by changing their `title` and `uid` slugs in the dashboard JSON.
> 
> Repoints Grafana provisioning to the renamed full-model dashboard by updating `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH` in `docker-compose.yaml` and the `dashboardUid`/annotation references in `provisioning/alerting/alert_rules.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72c7e91d41ba83c84cc3b3771d894dd5c467792c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->