### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 (2026-03-13)
+
+### Features
+
+- **Standard datasource URL**: Use Grafana's standard `url` field for the Cube API endpoint instead of `jsonData.cubeApiUrl`, with backward-compatible fallback (#177)
+- **Generated data model dashboard**: Added a provisioned demo dashboard for the generated data model (#175)
+- **Refreshed demo dashboards**: Updated provisioned demo dashboards to reflect current plugin capabilities (#184)
+
+### Bug Fixes
+
+- **Stale SQL preview**: SQL preview now refreshes when dashboard variables change (#150)
 
 ### Deprecated
 
@@ -17,6 +27,8 @@
   -       cubeApiUrl: http://localhost:4000
   +     url: http://localhost:4000
   ```
+
+**Full Changelog**: [v0.2.0...v0.3.0](https://github.com/grafana/grafana-cube-datasource/compare/v0.2.0...v0.3.0)
 
 ## 0.2.0 (2026-02-18)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

Version bump to v0.3.0 with changelog update.

### Notable changes since v0.2.0

- **Standard datasource URL**: Use Grafana's standard `url` field for Cube API endpoint (#177)
- **SQL preview fix**: Refresh SQL preview when dashboard variables change (#150)
- **New demo dashboards**: Generated data model dashboard (#175) and refreshed existing dashboards (#184)
- **Deprecation**: `jsonData.cubeApiUrl` field deprecated in favour of standard `url` field

## After merge

Tag the release on main:

```bash
git checkout main && git pull
git tag v0.3.0
git push origin v0.3.0
```


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and package version metadata updates only, with no runtime code changes.
> 
> **Overview**
> Prepares the `v0.3.0` release by bumping the version in `package.json`/`package-lock.json`.
> 
> Updates `CHANGELOG.md` with the `0.3.0` entry, including notes about the switch to the standard datasource `url` field (and deprecation of `jsonData.cubeApiUrl`), demo dashboard updates, and the SQL preview refresh fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe95a73beeb7f3796ddbc9a93f352d44a7358117. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->