### PR TITLE
docs: fix migration diff in changelog to preserve jsonData key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@
     datasources:
       - name: Cube
         type: grafana-cube-datasource
-  -     jsonData:
-  -       cubeApiUrl: http://localhost:4000
   +     url: http://localhost:4000
+        jsonData:
+  -       cubeApiUrl: http://localhost:4000
+  +       # cubeApiUrl is no longer needed for the URL
   ```
 
 **Full Changelog**: [v0.2.0...v0.3.0](https://github.com/grafana/grafana-cube-datasource/compare/v0.2.0...v0.3.0)


### PR DESCRIPTION
The migration diff previously implied removing the entire `jsonData` key, which could be misleading if other fields exist under it. Updated to show removing only the `cubeApiUrl` entry.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies the provisioning migration example without affecting runtime behavior.
> 
> **Overview**
> Updates the `CHANGELOG.md` migration snippet for deprecating `jsonData.cubeApiUrl` to show adding the top-level `url` while **preserving the `jsonData` block**, removing only the `cubeApiUrl` entry to avoid implying other `jsonData` fields should be deleted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed81d06771b4078f93b5ac902b3f043d63d37983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->