### PR TITLE
feat: migrate dev environment from PostgreSQL to DuckDB

### DIFF
--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -68,6 +68,13 @@ RUN if [ "${development}" = "true" ]; then \
     go run bootstrap.go; \
     fi
 
+# Install MotherDuck DuckDB datasource plugin
+ARG DUCKDB_PLUGIN_VERSION=0.4.1
+RUN curl -sL "https://github.com/motherduckdb/grafana-duckdb-datasource/releases/download/v${DUCKDB_PLUGIN_VERSION}/motherduck-duckdb-datasource-${DUCKDB_PLUGIN_VERSION}.zip" \
+    -o /tmp/duckdb-plugin.zip \
+    && unzip /tmp/duckdb-plugin.zip -d /var/lib/grafana/plugins/ \
+    && rm /tmp/duckdb-plugin.zip
+
 # Inject livereload script into grafana index.html
 RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></script></body>|g' /usr/share/grafana/public/views/index.html
 

--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -68,15 +68,20 @@ RUN if [ "${development}" = "true" ]; then \
     go run bootstrap.go; \
     fi
 
-# Install MotherDuck DuckDB datasource plugin (glibc binary; requires Ubuntu-based Grafana image)
+# Install MotherDuck DuckDB datasource plugin.
+# The plugin binary requires glibc so it only loads on Ubuntu-based Grafana images.
+# On Alpine (CI), the files are extracted but Grafana will log a backend error at startup;
+# this is harmless — the datasource simply won't be functional.
 ARG DUCKDB_PLUGIN_VERSION=0.4.1
 RUN if grep -i -q ubuntu /etc/issue; then \
-        DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*; \
+        DEBIAN_FRONTEND=noninteractive apt-get update \
+        && apt-get install -y --no-install-recommends unzip \
+        && rm -rf /var/lib/apt/lists/*; \
     fi \
     && curl -sL "https://github.com/motherduckdb/grafana-duckdb-datasource/releases/download/v${DUCKDB_PLUGIN_VERSION}/motherduck-duckdb-datasource-${DUCKDB_PLUGIN_VERSION}.zip" \
        -o /tmp/duckdb-plugin.zip \
-    && unzip /tmp/duckdb-plugin.zip -d /var/lib/grafana/plugins/ \
-    && rm /tmp/duckdb-plugin.zip
+    && (unzip /tmp/duckdb-plugin.zip -d /var/lib/grafana/plugins/ || true) \
+    && rm -f /tmp/duckdb-plugin.zip
 
 # Inject livereload script into grafana index.html
 RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></script></body>|g' /usr/share/grafana/public/views/index.html

--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -1,7 +1,8 @@
 ARG grafana_version=latest@sha256:8e8fc4c728843dfc460e7c4c52317eebe71b647b52b4af5fb2f62af7d8831e7d
 ARG grafana_image=grafana-enterprise
+ARG grafana_suffix=-ubuntu
 
-FROM grafana/${grafana_image}:${grafana_version}
+FROM grafana/${grafana_image}:${grafana_version}${grafana_suffix}
 
 ARG anonymous_auth_enabled=true
 ARG development=false
@@ -69,19 +70,16 @@ RUN if [ "${development}" = "true" ]; then \
     fi
 
 # Install MotherDuck DuckDB datasource plugin.
-# The plugin binary requires glibc so it only loads on Ubuntu-based Grafana images.
-# On Alpine (CI), the files are extracted but Grafana will log a backend error at startup;
-# this is harmless — the datasource simply won't be functional.
+# The plugin binary requires glibc, so the grafana_suffix build arg defaults to
+# -ubuntu to ensure all environments (local dev + CI) use an Ubuntu-based image.
 ARG DUCKDB_PLUGIN_VERSION=0.4.1
-RUN if grep -i -q ubuntu /etc/issue; then \
-        DEBIAN_FRONTEND=noninteractive apt-get update \
-        && apt-get install -y --no-install-recommends unzip \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && curl -sL "https://github.com/motherduckdb/grafana-duckdb-datasource/releases/download/v${DUCKDB_PLUGIN_VERSION}/motherduck-duckdb-datasource-${DUCKDB_PLUGIN_VERSION}.zip" \
        -o /tmp/duckdb-plugin.zip \
-    && (unzip /tmp/duckdb-plugin.zip -d /var/lib/grafana/plugins/ || true) \
-    && rm -f /tmp/duckdb-plugin.zip
+    && unzip /tmp/duckdb-plugin.zip -d /var/lib/grafana/plugins/ \
+    && rm /tmp/duckdb-plugin.zip
 
 # Inject livereload script into grafana index.html
 RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></script></body>|g' /usr/share/grafana/public/views/index.html

--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -68,10 +68,13 @@ RUN if [ "${development}" = "true" ]; then \
     go run bootstrap.go; \
     fi
 
-# Install MotherDuck DuckDB datasource plugin
+# Install MotherDuck DuckDB datasource plugin (glibc binary; requires Ubuntu-based Grafana image)
 ARG DUCKDB_PLUGIN_VERSION=0.4.1
-RUN curl -sL "https://github.com/motherduckdb/grafana-duckdb-datasource/releases/download/v${DUCKDB_PLUGIN_VERSION}/motherduck-duckdb-datasource-${DUCKDB_PLUGIN_VERSION}.zip" \
-    -o /tmp/duckdb-plugin.zip \
+RUN if grep -i -q ubuntu /etc/issue; then \
+        DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*; \
+    fi \
+    && curl -sL "https://github.com/motherduckdb/grafana-duckdb-datasource/releases/download/v${DUCKDB_PLUGIN_VERSION}/motherduck-duckdb-datasource-${DUCKDB_PLUGIN_VERSION}.zip" \
+       -o /tmp/duckdb-plugin.zip \
     && unzip /tmp/duckdb-plugin.zip -d /var/lib/grafana/plugins/ \
     && rm /tmp/duckdb-plugin.zip
 

--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -72,7 +72,9 @@ RUN if [ "${development}" = "true" ]; then \
 # Install MotherDuck DuckDB datasource plugin.
 # The plugin binary requires glibc, so the grafana_suffix build arg defaults to
 # -ubuntu to ensure all environments (local dev + CI) use an Ubuntu-based image.
-ARG DUCKDB_PLUGIN_VERSION=0.4.1
+# Pinned to v0.2.1 (DuckDB 1.2.2) — later versions require glibc >= 2.38 which
+# exceeds the glibc 2.35 shipped in Grafana's Ubuntu 22.04 base image.
+ARG DUCKDB_PLUGIN_VERSION=0.2.1
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -1,4 +1,4 @@
-ARG grafana_version=latest@sha256:8e8fc4c728843dfc460e7c4c52317eebe71b647b52b4af5fb2f62af7d8831e7d
+ARG grafana_version=latest
 ARG grafana_image=grafana-enterprise
 ARG grafana_suffix=-ubuntu
 

--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -8,6 +8,7 @@ services:
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-12.3.3}
+        grafana_suffix: ${GRAFANA_SUFFIX:--ubuntu}
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:

--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -28,4 +28,4 @@ services:
       GF_LOG_FILTERS: plugin.grafana-cube-datasource:debug
       GF_LOG_LEVEL: debug
       GF_DATAPROXY_LOGGING: 1
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-cube-datasource
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-cube-datasource,motherduck-duckdb-datasource

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -42,8 +42,9 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      # Skip the grafana-dev image in Playwright tests (image may be temporarily unavailable)
+      # Skip images without -ubuntu variants (DuckDB plugin binary requires glibc)
       run-playwright-with-skip-grafana-dev-image: true
+      run-playwright-with-skip-grafana-react-19-preview-image: true
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to publish.yaml:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,5 +28,5 @@ Both frontend (`npm run build`) and backend (`mage -v`) must be built **before**
 
 - Playwright E2E tests (`npm run e2e`) require services to be up first. Use `--reporter=list` to avoid the interactive HTML report blocking the terminal.
 - `mage -v` builds all 6 platform binaries by default. Use `mage -v build:linux` to build only the Linux binary (faster for local dev).
-- Grafana uses the Ubuntu-based image (`12.3.3-ubuntu`) because the DuckDB datasource plugin binary requires glibc.
+- Grafana uses Ubuntu-based images (via the `grafana_suffix` build arg, defaulting to `-ubuntu`) because the DuckDB datasource plugin binary requires glibc. This applies to both local dev and CI.
 - The duckdb-init container creates two copies of the database file (one for Cube, one for Grafana) to avoid DuckDB write-lock contention.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,4 +29,4 @@ Both frontend (`npm run build`) and backend (`mage -v`) must be built **before**
 - Playwright E2E tests (`npm run e2e`) require services to be up first. Use `--reporter=list` to avoid the interactive HTML report blocking the terminal.
 - `mage -v` builds all 6 platform binaries by default. Use `mage -v build:linux` to build only the Linux binary (faster for local dev).
 - Grafana uses Ubuntu-based images (via the `grafana_suffix` build arg, defaulting to `-ubuntu`) because the DuckDB datasource plugin binary requires glibc. This applies to both local dev and CI.
-- The duckdb-init container creates two copies of the database file (one for Cube, one for Grafana) to avoid DuckDB write-lock contention.
+- Cube and Grafana share a single DuckDB database file. Grafana connects in read-only mode (`access_mode=READ_ONLY`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ Three services run via `docker compose up --build -d` from the repo root:
 |---------|------|---------|
 | Grafana | 3000 | Hosts the plugin (anonymous Admin auth, no login needed) |
 | Cube | 4000 | Semantic layer REST API |
-| PostgreSQL | 5432 | Cube's backing database (JaffleShop sample data) |
+| duckdb-init | — | Init container that seeds a DuckDB database from CSV data, then exits |
+
+Cube uses DuckDB as its backing database (JaffleShop sample data). Grafana includes the MotherDuck DuckDB datasource plugin for direct SQL querying.
 
 ### Starting services
 
@@ -26,3 +28,5 @@ Both frontend (`npm run build`) and backend (`mage -v`) must be built **before**
 
 - Playwright E2E tests (`npm run e2e`) require services to be up first. Use `--reporter=list` to avoid the interactive HTML report blocking the terminal.
 - `mage -v` builds all 6 platform binaries by default. Use `mage -v build:linux` to build only the Linux binary (faster for local dev).
+- Grafana uses the Ubuntu-based image (`12.3.3-ubuntu`) because the DuckDB datasource plugin binary requires glibc.
+- The duckdb-init container creates two copies of the database file (one for Cube, one for Grafana) to avoid DuckDB write-lock contention.

--- a/dev-environment/README.md
+++ b/dev-environment/README.md
@@ -1,6 +1,6 @@
 # Development Environment
 
-This directory contains the development infrastructure for running Cube and Postgres alongside the Grafana plugin during development and testing.
+This directory contains the development infrastructure for running Cube and DuckDB alongside the Grafana plugin during development and testing. DuckDB is configured as the data source, providing BigQuery-compatible SQL semantics.
 
 ## Structure
 
@@ -9,22 +9,22 @@ This directory contains the development infrastructure for running Cube and Post
   - `model/views/` - Cube views and derived metrics
   - `package.json` - Cube project configuration
 - `data/` - Database setup and sample data
-  - `migrations/init.sql` - Database schema and data loading
+  - `Dockerfile` - DuckDB CLI init container
+  - `migrations/init.sql` - Database schema and data loading (DuckDB SQL)
   - `seeds/` - CSV files with sample JaffleShop data
 
 ## Usage
 
 The docker-compose.yaml in the parent directory will automatically:
 
-1. Start Postgres with the sample data loaded
-2. Start Cube connected to Postgres
-3. Start Grafana with the plugin loaded
+1. Build a DuckDB init container to create and seed the database
+2. Start Cube connected to the DuckDB database file
+3. Start Grafana with both the Cube plugin and the DuckDB datasource plugin loaded
 
 All services will be available at:
 
-- Grafana: localhost:3000 (admin/admin)
+- Grafana: localhost:3000 (anonymous Admin auth, no login needed)
 - Cube API: localhost:4000
-- Postgres: localhost:5432 (user/password, database: jaffle_shop)
 
 ## Sample Data
 

--- a/dev-environment/cube/.env
+++ b/dev-environment/cube/.env
@@ -1,10 +1,6 @@
 # Database Configuration
-CUBEJS_DB_TYPE=postgres
-CUBEJS_DB_HOST=postgres
-CUBEJS_DB_PORT=5432
-CUBEJS_DB_NAME=jaffle_shop
-CUBEJS_DB_USER=user
-CUBEJS_DB_PASS=password
+CUBEJS_DB_TYPE=duckdb
+CUBEJS_DB_DUCKDB_DATABASE_PATH=/cube/data/jaffle_shop.duckdb
 
 # Cube.js Configuration
 CUBEJS_API_SECRET=dd122a535ad5d703a9d8977179f118bc

--- a/dev-environment/cube/.env
+++ b/dev-environment/cube/.env
@@ -1,6 +1,6 @@
 # Database Configuration
 CUBEJS_DB_TYPE=duckdb
-CUBEJS_DB_DUCKDB_DATABASE_PATH=/cube/data/jaffle_shop.duckdb
+CUBEJS_DB_DUCKDB_DATABASE_PATH=/cube/data/jaffle_shop.duckdb?access_mode=read_only
 
 # Cube.js Configuration
 CUBEJS_API_SECRET=dd122a535ad5d703a9d8977179f118bc

--- a/dev-environment/data/Dockerfile
+++ b/dev-environment/data/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.21
+
+ARG DUCKDB_VERSION=v1.2.1
+ARG TARGETARCH
+
+RUN apk add --no-cache curl unzip \
+    && ARCH=$(case "${TARGETARCH:-amd64}" in arm64) echo "aarch64";; *) echo "amd64";; esac) \
+    && curl -sL "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-${ARCH}.zip" \
+       -o /tmp/duckdb.zip \
+    && unzip /tmp/duckdb.zip -d /usr/local/bin/ \
+    && chmod +x /usr/local/bin/duckdb \
+    && rm /tmp/duckdb.zip
+
+WORKDIR /data
+ENTRYPOINT ["duckdb"]

--- a/dev-environment/data/Dockerfile
+++ b/dev-environment/data/Dockerfile
@@ -1,15 +1,19 @@
-FROM alpine:3.21
+FROM debian:bookworm-slim
 
 ARG DUCKDB_VERSION=v1.2.1
 ARG TARGETARCH
 
-RUN apk add --no-cache curl unzip \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl unzip ca-certificates \
     && ARCH=$(case "${TARGETARCH:-amd64}" in arm64) echo "aarch64";; *) echo "amd64";; esac) \
     && curl -sL "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-${ARCH}.zip" \
        -o /tmp/duckdb.zip \
     && unzip /tmp/duckdb.zip -d /usr/local/bin/ \
     && chmod +x /usr/local/bin/duckdb \
-    && rm /tmp/duckdb.zip
+    && rm /tmp/duckdb.zip \
+    && apt-get purge -y curl unzip \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /data
 ENTRYPOINT ["duckdb"]

--- a/dev-environment/data/migrations/init.sql
+++ b/dev-environment/data/migrations/init.sql
@@ -1,4 +1,8 @@
-CREATE TABLE IF NOT EXISTS customers (
+DROP TABLE IF EXISTS payments;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS customers;
+
+CREATE TABLE customers (
     id INTEGER PRIMARY KEY,
     first_name VARCHAR(50),
     last_name VARCHAR(50),
@@ -27,7 +31,7 @@ UPDATE customers SET
         ELSE 'startup'
     END;
 
-CREATE TABLE IF NOT EXISTS orders (
+CREATE TABLE orders (
     id INTEGER PRIMARY KEY,
     customer_id INTEGER REFERENCES customers(id),
     order_date DATE,
@@ -55,7 +59,7 @@ UPDATE orders SET
         ELSE 4
     END;
 
-CREATE TABLE IF NOT EXISTS payments (
+CREATE TABLE payments (
     id INTEGER PRIMARY KEY,
     order_id INTEGER REFERENCES orders(id),
     payment_method VARCHAR(20),

--- a/dev-environment/data/migrations/init.sql
+++ b/dev-environment/data/migrations/init.sql
@@ -7,14 +7,19 @@ CREATE TABLE IF NOT EXISTS customers (
     created_at TIMESTAMP,
     customer_segment VARCHAR(20)
 );
-COPY customers (id, first_name, last_name) FROM '/data/seeds/customers.csv' DELIMITER ',' CSV HEADER;
+INSERT INTO customers (id, first_name, last_name)
+SELECT id, first_name, last_name
+FROM read_csv('/data/seeds/customers.csv', header = true, columns = {
+    'id': 'INTEGER',
+    'first_name': 'VARCHAR',
+    'last_name': 'VARCHAR'
+});
 
--- Add comprehensive test data
 UPDATE customers SET
-    email = LOWER(first_name || '.' || last_name || '@example.com'),
-    is_active = (id % 3 != 0),  -- Mix of true/false
-    created_at = '2017-01-01'::timestamp + (id || ' days')::interval,
-    customer_segment = CASE 
+    email = LOWER(CONCAT(first_name, '.', last_name, '@example.com')),
+    is_active = (id % 3 != 0),
+    created_at = CAST('2017-01-01' AS TIMESTAMP) + INTERVAL (id) DAY,
+    customer_segment = CASE
         WHEN id % 5 = 0 THEN 'enterprise'
         WHEN id % 5 = 1 THEN 'small_business'
         WHEN id % 5 = 2 THEN 'individual'
@@ -24,22 +29,26 @@ UPDATE customers SET
 
 CREATE TABLE IF NOT EXISTS orders (
     id INTEGER PRIMARY KEY,
-    customer_id INTEGER,
+    customer_id INTEGER REFERENCES customers(id),
     order_date DATE,
     status VARCHAR(20),
     created_at TIMESTAMP,
     is_gift BOOLEAN,
-    priority INTEGER,
-    CONSTRAINT orders_customer_id_fkey
-        FOREIGN KEY (customer_id) REFERENCES customers(id)
+    priority INTEGER
 );
-COPY orders (id, customer_id, order_date, status) FROM '/data/seeds/orders.csv' DELIMITER ',' CSV HEADER;
+INSERT INTO orders (id, customer_id, order_date, status)
+SELECT id, customer_id, order_date, status
+FROM read_csv('/data/seeds/orders.csv', header = true, columns = {
+    'id': 'INTEGER',
+    'customer_id': 'INTEGER',
+    'order_date': 'DATE',
+    'status': 'VARCHAR'
+});
 
--- Add comprehensive test data
 UPDATE orders SET
-    created_at = order_date::timestamp + (RANDOM() * 24 || ' hours')::interval,
-    is_gift = (id % 7 = 0),  -- Some orders are gifts
-    priority = CASE 
+    created_at = CAST(order_date AS TIMESTAMP) + INTERVAL (CAST(FLOOR(RANDOM() * 24) AS INTEGER)) HOUR,
+    is_gift = (id % 7 = 0),
+    priority = CASE
         WHEN status = 'placed' THEN 1
         WHEN status = 'shipped' THEN 2
         WHEN status IN ('completed', 'returned') THEN 3
@@ -48,7 +57,7 @@ UPDATE orders SET
 
 CREATE TABLE IF NOT EXISTS payments (
     id INTEGER PRIMARY KEY,
-    order_id INTEGER,
+    order_id INTEGER REFERENCES orders(id),
     payment_method VARCHAR(20),
     amount DECIMAL(10,2),
     tax DECIMAL(10,2),
@@ -57,34 +66,39 @@ CREATE TABLE IF NOT EXISTS payments (
     refund_amount DECIMAL(10,2),
     created_at TIMESTAMP,
     is_successful BOOLEAN,
-    currency VARCHAR(3),
-    CONSTRAINT payments_order_id_fkey
-        FOREIGN KEY (order_id) REFERENCES orders(id)
+    currency VARCHAR(3)
 );
-COPY payments (id, order_id, payment_method, amount, tax, discount, processing_fee) FROM '/data/seeds/payments.csv' DELIMITER ',' CSV HEADER;
+INSERT INTO payments (id, order_id, payment_method, amount, tax, discount, processing_fee)
+SELECT id, order_id, payment_method, amount, tax, discount, processing_fee
+FROM read_csv('/data/seeds/payments.csv', header = true, columns = {
+    'id': 'INTEGER',
+    'order_id': 'INTEGER',
+    'payment_method': 'VARCHAR',
+    'amount': 'DECIMAL(10,2)',
+    'tax': 'DECIMAL(10,2)',
+    'discount': 'DECIMAL(10,2)',
+    'processing_fee': 'DECIMAL(10,2)'
+});
 
--- Add comprehensive test data including edge cases
 UPDATE payments SET
-    -- Add refunds (negative numbers)
-    refund_amount = CASE 
-        WHEN id % 10 = 0 THEN -amount  -- Full refund
-        WHEN id % 15 = 0 AND id % 10 != 0 THEN -(amount * 0.5)  -- Partial refund (exclude overlaps)
+    refund_amount = CASE
+        WHEN id % 10 = 0 THEN -amount
+        WHEN id % 15 = 0 AND id % 10 != 0 THEN -(amount * 0.5)
         ELSE 0.00
     END,
-    created_at = '2018-01-01'::timestamp + (id || ' hours')::interval,
-    is_successful = (id % 20 != 0),  -- 5% failure rate
-    currency = CASE 
+    created_at = CAST('2018-01-01' AS TIMESTAMP) + INTERVAL (id) HOUR,
+    is_successful = (id % 20 != 0),
+    currency = CASE
         WHEN id % 10 = 0 THEN 'EUR'
         WHEN id % 10 = 1 THEN 'GBP'
         WHEN id % 10 = 2 THEN 'JPY'
         ELSE 'USD'
     END;
 
--- Add some NULL values for comprehensive testing
 UPDATE payments SET
-    discount = NULL 
+    discount = NULL
 WHERE id % 25 = 0;
 
 UPDATE payments SET
-    processing_fee = NULL 
+    processing_fee = NULL
 WHERE id % 30 = 0;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,9 @@ services:
     container_name: 'grafana-itself'
     build:
       args:
-        grafana_version: ${GRAFANA_VERSION:-12.3.3-ubuntu}
+        grafana_version: ${GRAFANA_VERSION:-12.3.3}
         grafana_image: ${GRAFANA_IMAGE:-grafana}
+        grafana_suffix: ${GRAFANA_SUFFIX:--ubuntu}
     environment:
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cubeds-ecom-full-data-model.json
       GF_FEATURE_TOGGLES_ENABLE: 'tableNextGen,queryLibrary,sqlExpressions,dashboardDsAdHocFiltering,adhocFiltersInTooltips'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,6 @@
+volumes:
+  duckdb-data:
+
 services:
   grafana:
     extends:
@@ -11,8 +14,13 @@ services:
     environment:
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cubeds-ecom-full-data-model.json
       GF_FEATURE_TOGGLES_ENABLE: 'tableNextGen,queryLibrary,sqlExpressions,dashboardDsAdHocFiltering,adhocFiltersInTooltips'
+    volumes:
+      - duckdb-data:/var/lib/grafana/duckdb
     depends_on:
-      - cube
+      cube:
+        condition: service_started
+      duckdb-init:
+        condition: service_completed_successfully
 
   cube:
     image: cubejs/cube:latest@sha256:6a2e73d4e36ac3ddc05fc90f8ad068f39458227c1c3c4583e14ea97407785a26
@@ -21,30 +29,16 @@ services:
       - 15432:15432
     volumes:
       - ./dev-environment/cube:/cube/conf
+      - duckdb-data:/cube/data
     depends_on:
-      - postgres
+      duckdb-init:
+        condition: service_completed_successfully
 
-  postgres:
-    image: postgres:18@sha256:98f32d2e093deea07127bcc373f89729b77ff3486511cc77224c530e63a41f0e
-    environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: jaffle_shop
-    ports:
-      - '5432:5432'
+  duckdb-init:
+    build:
+      context: dev-environment/data
     volumes:
-      - ./dev-environment/data/seeds/:/data/seeds/
-      - ./dev-environment/data/migrations/init.sql:/docker-entrypoint-initdb.d/init.sql
-    # Enable SQL queries in the logs (minimal output)
-    command:
-      [
-        'postgres',
-        '-c',
-        'log_statement=all',
-        '-c',
-        'log_line_prefix=',
-        '-c',
-        'log_duration=off',
-        '-c',
-        'log_parameter_max_length=0',
-      ]
+      - ./dev-environment/data/seeds:/data/seeds:ro
+      - ./dev-environment/data/migrations:/data/migrations:ro
+      - duckdb-data:/data/db
+    command: ['/data/db/jaffle_shop.duckdb', '-init', '/data/migrations/init.sql', '-c', 'SELECT count(*) FROM customers; SELECT count(*) FROM orders; SELECT count(*) FROM payments;']

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,4 +47,3 @@ services:
       - |
         duckdb /data/db/jaffle_shop.duckdb -init /data/migrations/init.sql \
           -c 'SELECT count(*) FROM customers; SELECT count(*) FROM orders; SELECT count(*) FROM payments;'
-        cp /data/db/jaffle_shop.duckdb /data/db/grafana_jaffle_shop.duckdb

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     container_name: 'grafana-itself'
     build:
       args:
-        grafana_version: ${GRAFANA_VERSION:-12.3.3}
+        grafana_version: ${GRAFANA_VERSION:-12.3.3-ubuntu}
         grafana_image: ${GRAFANA_IMAGE:-grafana}
     environment:
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cubeds-ecom-full-data-model.json
@@ -41,4 +41,9 @@ services:
       - ./dev-environment/data/seeds:/data/seeds:ro
       - ./dev-environment/data/migrations:/data/migrations:ro
       - duckdb-data:/data/db
-    command: ['/data/db/jaffle_shop.duckdb', '-init', '/data/migrations/init.sql', '-c', 'SELECT count(*) FROM customers; SELECT count(*) FROM orders; SELECT count(*) FROM payments;']
+    entrypoint: ['/bin/sh', '-c']
+    command:
+      - |
+        duckdb /data/db/jaffle_shop.duckdb -init /data/migrations/init.sql \
+          -c 'SELECT count(*) FROM customers; SELECT count(*) FROM orders; SELECT count(*) FROM payments;'
+        cp /data/db/jaffle_shop.duckdb /data/db/grafana_jaffle_shop.duckdb

--- a/provisioning/dashboards/territory-navigator.json
+++ b/provisioning/dashboards/territory-navigator.json
@@ -25,8 +25,8 @@
   "panels": [
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -122,8 +122,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -210,8 +210,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -301,8 +301,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -392,8 +392,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -482,8 +482,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -570,8 +570,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -721,8 +721,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -849,8 +849,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1019,8 +1019,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1124,8 +1124,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1304,8 +1304,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1480,8 +1480,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1701,8 +1701,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1893,8 +1893,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2080,8 +2080,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2170,8 +2170,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2376,8 +2376,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2564,8 +2564,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2770,8 +2770,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2977,8 +2977,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3703,8 +3703,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3893,8 +3893,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4100,8 +4100,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4208,8 +4208,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4444,8 +4444,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4761,8 +4761,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4890,8 +4890,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -5500,8 +5500,8 @@
     },
     {
       "datasource": {
-        "type": "postgres",
-        "uid": "postgres-datasource"
+        "type": "motherduck-duckdb-datasource",
+        "uid": "duckdb-datasource"
       },
       "fieldConfig": {
         "defaults": {

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -24,4 +24,4 @@ datasources:
     editable: true
     uid: 'duckdb-datasource'
     jsonData:
-      path: '/var/lib/grafana/duckdb/grafana_jaffle_shop.duckdb'
+      path: '/var/lib/grafana/duckdb/jaffle_shop.duckdb?access_mode=READ_ONLY'

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -24,4 +24,4 @@ datasources:
     editable: true
     uid: 'duckdb-datasource'
     jsonData:
-      path: '/var/lib/grafana/duckdb/jaffle_shop.duckdb'
+      path: '/var/lib/grafana/duckdb/grafana_jaffle_shop.duckdb'

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -12,24 +12,16 @@ datasources:
     url: 'http://cube:4000'
     jsonData:
       deploymentType: 'self-hosted'
-      exploreSqlDatasourceUid: 'postgres-datasource'
+      exploreSqlDatasourceUid: 'duckdb-datasource'
     secureJsonData:
       apiSecret: 'dd122a535ad5d703a9d8977179f118bc'
-  - name: 'PostgreSQL'
-    type: 'postgres'
+  - name: 'DuckDB'
+    type: 'motherduck-duckdb-datasource'
     access: proxy
     isDefault: false
     orgId: 1
     version: 1
     editable: true
-    uid: 'postgres-datasource'
-    url: 'postgres:5432'
-    database: 'jaffle_shop'
-    user: 'user'
+    uid: 'duckdb-datasource'
     jsonData:
-      sslmode: 'disable'
-      postgresVersion: 1000
-      timescaledb: false
-      database: 'jaffle_shop'
-    secureJsonData:
-      password: 'password'
+      path: '/var/lib/grafana/duckdb/jaffle_shop.duckdb'

--- a/src/services/datasourceApi.ts
+++ b/src/services/datasourceApi.ts
@@ -23,6 +23,7 @@ const SQL_DATASOURCE_KEYWORDS = [
   'trino',
   'presto',
   'cockroach',
+  'duckdb',
 ];
 
 // Helper function to check if a datasource type is SQL-compatible using fuzzy matching

--- a/tests/sqlPreviewExplore.spec.ts
+++ b/tests/sqlPreviewExplore.spec.ts
@@ -61,34 +61,15 @@ test.describe('SQLPreview Explore Integration', () => {
       await expect(page).toHaveURL(/\/explore/, { timeout: 10000 });
     }
 
-    // Since we're on Explore page (URL check passed), verify the key functionality:
-    // 1. DuckDB datasource should be selected (or at least visible)
-    // 2. SQL query should be present somewhere on the page
-    // 3. No critical errors should be displayed
+    // The Explore page behavior depends on the DuckDB datasource plugin being
+    // loadable (requires glibc). On Alpine-based Grafana images (CI), the plugin
+    // binary can't load and the page shows an error instead of the SQL query.
+    // We only assert on Explore page content when the datasource is functional.
+    const bodyText = await page.locator('body').textContent({ timeout: 5000 });
+    const datasourceLoaded = !bodyText?.includes('Unknown error');
 
-    // Look for datasource picker and DuckDB
-    try {
-      await expect(
-        page.locator('input[value*="DuckDB"], [data-testid*="datasource"] *:has-text("DuckDB")')
-      ).toBeVisible({ timeout: 5000 });
-    } catch {
-      // Datasource picker might have different structure, that's ok for now
-      console.log('DuckDB datasource picker not found with expected selectors');
-    }
-
-    // Verify SQL query is present on the page (should contain our SELECT statement)
-    await expect(page.locator('body')).toContainText('SELECT', { timeout: 5000 });
-
-    // Verify we're not showing any critical error states
-    const errorSelectors = [
-      '[data-testid*="error"]',
-      '.alert-error',
-      '*:has-text("An unexpected error")',
-      '*:has-text("Failed to")',
-    ];
-
-    for (const selector of errorSelectors) {
-      await expect(page.locator(selector)).not.toBeVisible();
+    if (datasourceLoaded) {
+      await expect(page.locator('body')).toContainText('SELECT', { timeout: 5000 });
     }
   });
 

--- a/tests/sqlPreviewExplore.spec.ts
+++ b/tests/sqlPreviewExplore.spec.ts
@@ -32,7 +32,7 @@ test.describe('SQLPreview Explore Integration', () => {
     await expect(exploreButton).toHaveAttribute('href');
     const href = await exploreButton.getAttribute('href');
     expect(href).toContain('/explore?left=');
-    expect(href).toContain('postgres-datasource');
+    expect(href).toContain('duckdb-datasource');
 
     // Get the SQL text that should be passed to Explore
     const sqlText = await sqlPreview.textContent();
@@ -62,18 +62,18 @@ test.describe('SQLPreview Explore Integration', () => {
     }
 
     // Since we're on Explore page (URL check passed), verify the key functionality:
-    // 1. PostgreSQL datasource should be selected (or at least visible)
+    // 1. DuckDB datasource should be selected (or at least visible)
     // 2. SQL query should be present somewhere on the page
     // 3. No critical errors should be displayed
 
-    // Look for datasource picker and PostgreSQL
+    // Look for datasource picker and DuckDB
     try {
       await expect(
-        page.locator('input[value*="PostgreSQL"], [data-testid*="datasource"] *:has-text("PostgreSQL")')
+        page.locator('input[value*="DuckDB"], [data-testid*="datasource"] *:has-text("DuckDB")')
       ).toBeVisible({ timeout: 5000 });
     } catch {
       // Datasource picker might have different structure, that's ok for now
-      console.log('PostgreSQL datasource picker not found with expected selectors');
+      console.log('DuckDB datasource picker not found with expected selectors');
     }
 
     // Verify SQL query is present on the page (should contain our SELECT statement)
@@ -154,9 +154,8 @@ test.describe('SQLPreview Explore Integration', () => {
     expect(leftParam).toBeTruthy();
 
     const exploreState = JSON.parse(decodeURIComponent(leftParam!));
-    expect(exploreState.datasource.uid).toBe('postgres-datasource');
-    // Type can be 'postgres' (older Grafana) or 'grafana-postgresql-datasource' (newer Grafana)
-    expect(exploreState.datasource.type).toContain('postgres');
+    expect(exploreState.datasource.uid).toBe('duckdb-datasource');
+    expect(exploreState.datasource.type).toContain('duckdb');
     expect(exploreState.queries).toHaveLength(1);
     expect(exploreState.queries[0].rawSql).toContain('SELECT');
     // format field is omitted to let each datasource use its default

--- a/tests/sqlPreviewExplore.spec.ts
+++ b/tests/sqlPreviewExplore.spec.ts
@@ -63,13 +63,13 @@ test.describe('SQLPreview Explore Integration', () => {
 
     // The Explore page behavior depends on the DuckDB datasource plugin being
     // loadable (requires glibc). On Alpine-based Grafana images (CI), the plugin
-    // binary can't load and the page shows an error instead of the SQL query.
-    // We only assert on Explore page content when the datasource is functional.
-    const bodyText = await page.locator('body').textContent({ timeout: 5000 });
-    const datasourceLoaded = !bodyText?.includes('Unknown error');
-
-    if (datasourceLoaded) {
-      await expect(page.locator('body')).toContainText('SELECT', { timeout: 5000 });
+    // binary can't load and the page may show an error instead of the SQL query.
+    // Wait for either the SQL query or an error to appear, then assert only if
+    // the datasource loaded successfully.
+    try {
+      await expect(page.locator('body')).toContainText('SELECT', { timeout: 10000 });
+    } catch {
+      // DuckDB datasource likely unavailable (Alpine/CI) — not a Cube plugin bug
     }
   });
 

--- a/tests/sqlPreviewExplore.spec.ts
+++ b/tests/sqlPreviewExplore.spec.ts
@@ -61,15 +61,34 @@ test.describe('SQLPreview Explore Integration', () => {
       await expect(page).toHaveURL(/\/explore/, { timeout: 10000 });
     }
 
-    // The Explore page behavior depends on the DuckDB datasource plugin being
-    // loadable (requires glibc). On Alpine-based Grafana images (CI), the plugin
-    // binary can't load and the page may show an error instead of the SQL query.
-    // Wait for either the SQL query or an error to appear, then assert only if
-    // the datasource loaded successfully.
+    // Since we're on Explore page (URL check passed), verify the key functionality:
+    // 1. DuckDB datasource should be selected (or at least visible)
+    // 2. SQL query should be present somewhere on the page
+    // 3. No critical errors should be displayed
+
+    // Look for datasource picker and DuckDB
     try {
-      await expect(page.locator('body')).toContainText('SELECT', { timeout: 10000 });
+      await expect(
+        page.locator('input[value*="DuckDB"], [data-testid*="datasource"] *:has-text("DuckDB")')
+      ).toBeVisible({ timeout: 5000 });
     } catch {
-      // DuckDB datasource likely unavailable (Alpine/CI) — not a Cube plugin bug
+      // Datasource picker might have different structure, that's ok for now
+      console.log('DuckDB datasource picker not found with expected selectors');
+    }
+
+    // Verify SQL query is present on the page (should contain our SELECT statement)
+    await expect(page.locator('body')).toContainText('SELECT', { timeout: 5000 });
+
+    // Verify we're not showing any critical error states
+    const errorSelectors = [
+      '[data-testid*="error"]',
+      '.alert-error',
+      '*:has-text("An unexpected error")',
+      '*:has-text("Failed to")',
+    ];
+
+    for (const selector of errorSelectors) {
+      await expect(page.locator(selector)).not.toBeVisible();
     }
   });
 


### PR DESCRIPTION
## Summary

Replaces PostgreSQL with DuckDB as the backing database for both Cube and Grafana in the local development environment.

I (Sam) had thought that we would be able to write BigQuery dialect everywhere, and not need to write Postgres dialect anywhere, if we were to switch to DuckDB and use the polyglot DuckDB extension to make it "speak" the BigQuery dialect. BUT it turns out that polyglot won't help us:

> What polyglot actually does
> It's a transpilation layer, not a dialect mode. It provides functions like polyglot_query('SELECT NOW()', 'bigquery') that convert SQL from one dialect to another before DuckDB executes it. It doesn't make DuckDB "natively speak BigQuery" -- every query needs to be explicitly routed through polyglot.

With #204 merged, the differences are now minimal anyway. All that's remaining is 

> `TO_CHAR` and `FORMAT_DATE` are vendor-specific functions with no shared lineage. It's not a syntax variation that a parser mode could bridge -- they're entirely different functions:
> 
> - PG/DuckDB: `TO_CHAR(current_date, 'Month')`
> - BigQuery: `FORMAT_DATE('%B', CURRENT_DATE())`
> 
> Even the format specifiers are different (`'Month'` vs `'%B'`). No dialect switch would make one engine understand the other's function.

Which is used for the dynamic field names which are present in: "February consumption" and "March Proj. Consumption" captions in this dummy data:
<img width="180" height="222" alt="image" src="https://github.com/user-attachments/assets/120bd78b-5a94-400e-8879-4d8d18729dca" />

Yet it could still be nice to make the change anticipated in this PR soon.
It would allow us to start using DuckDB, and start finding issues with it - it would get us closer to getting DuckDB working in GrafanaCloud. But that change is outside the scope of our current work - it can be deferred.


## What changed

### Infrastructure

* **Docker Compose**: Replaced the `postgres` service with a `duckdb-init` init container that creates and seeds a DuckDB database from CSV data
* **Shared volume**: Added `duckdb-data` Docker volume shared between Cube and Grafana containers
* **Grafana image**: All environments (local dev + CI) now use Ubuntu-based Grafana images via a `grafana_suffix` build arg (defaults to `-ubuntu`), because the DuckDB datasource plugin binary requires glibc
* **CI workflow**: Skip `grafana-dev` and React 19 preview images in Playwright tests (no `-ubuntu` variants available)

### Database

* **Single shared DuckDB file**: Cube and Grafana share one `jaffle_shop.duckdb` file on the `duckdb-data` volume. Grafana connects in `READ_ONLY` mode to prevent accidental mutations from Explore
* **`init.sql`**: Rewrote from PostgreSQL dialect to DuckDB-compatible SQL:
  * `COPY ... FROM ... CSV HEADER` → `read_csv()`
  * `::timestamp` / `::interval` casts → `CAST()` syntax
  * PostgreSQL string concat `||` → `CONCAT()`
  * PostgreSQL interval arithmetic → DuckDB `INTERVAL (n) UNIT` syntax
* **Cube config**: `CUBEJS_DB_TYPE=duckdb` with file-based database path

### Cube semantic layer

* **`orders.yml`**: Cast `order_date` (DATE column) to TIMESTAMP — BigQuery requires explicit DATE→TIMESTAMP promotion unlike PostgreSQL which auto-promotes

### Grafana

* **DuckDB plugin**: Installed MotherDuck DuckDB datasource plugin (v0.4.1) in Grafana Dockerfile
* **Datasource provisioning**: Replaced PostgreSQL datasource with DuckDB datasource (`duckdb-datasource`)
* **`exploreSqlDatasourceUid`**: Updated to point to `duckdb-datasource`
* **territory-navigator dashboard**: Updated panel-level datasource references from postgres to DuckDB, and replaced PG-specific `::date`/`::numeric` casts with standard SQL `CAST()` (via #204 merged into main)

### Plugin source

* **`datasourceApi.ts`**: Added `'duckdb'` to `SQL_DATASOURCE_KEYWORDS` for datasource discovery

### Tests

* **`sqlPreviewExplore.spec.ts`**: Updated E2E test expectations from `postgres-datasource` to `duckdb-datasource`

## Design decisions

1. **Single shared DuckDB file with READ_ONLY**: Neither Cube nor Grafana writes to the database in this dev environment, so a single file is sufficient. Grafana connects with `access_mode=READ_ONLY` to actively prevent accidental mutations from Explore.
2. **Ubuntu everywhere**: Rather than adding Alpine compatibility hacks (conditional unzip, try/catch in E2E tests), all environments use Ubuntu-based images via the `grafana_suffix` build arg. CI skips `grafana-dev` and React 19 preview images that lack `-ubuntu` variants.
3. **No polyglot extension needed**: The SQL in Cube YAML files is standard SQL (CASE, COALESCE, CAST, etc.) that works natively in both DuckDB and BigQuery. Polyglot could be added later if BigQuery-specific functions are needed.

## Known issues

* **Target-level datasource refs**: The `territory-navigator.json` dashboard has panel-level datasource fields updated to DuckDB, but individual `targets[].datasource` objects within panel `targets` arrays still reference `postgres`/`postgres-datasource`. These will need updating for the dashboard to fully work against DuckDB.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it replaces the dev/test database and provisioning (Docker Compose, seeded data, Grafana datasource) which can break local workflows and CI E2E expectations despite being non-production.
> 
> **Overview**
> Migrates the local dev/test environment from **PostgreSQL to a shared DuckDB file**, using a new `duckdb-init` container to create/seed `jaffle_shop.duckdb` and a `duckdb-data` volume shared by Cube and Grafana (Grafana mounted read-only).
> 
> Updates Grafana’s container build to default to Ubuntu images via `grafana_suffix` and installs the MotherDuck DuckDB datasource plugin (pinned), then switches provisioning and dashboards to use `motherduck-duckdb-datasource`/`duckdb-datasource` and allows the unsigned plugin to load.
> 
> Adjusts CI Playwright matrix to skip non-`-ubuntu` Grafana images, updates Cube’s `.env` to `duckdb`, rewrites seed SQL to DuckDB-compatible syntax, and updates SQL Explore/E2E expectations plus SQL datasource detection (`'duckdb'` keyword).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 289e86ff24774a8ce3c823c30276e3173a9bc657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->