### PR TITLE
chore: develop against latest Grafana

### DIFF
--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -7,7 +7,7 @@ services:
       context: .
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-        grafana_version: ${GRAFANA_VERSION:-12.3.3}
+        grafana_version: ${GRAFANA_VERSION:-main}
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,11 +6,11 @@ services:
     container_name: 'grafana-itself'
     build:
       args:
-        grafana_version: ${GRAFANA_VERSION:-12.3.3}
+        grafana_version: ${GRAFANA_VERSION:-main}
         grafana_image: ${GRAFANA_IMAGE:-grafana}
     environment:
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cubeds-ecom-full-data-model.json
-      GF_FEATURE_TOGGLES_ENABLE: 'tableNextGen,queryLibrary,sqlExpressions,dashboardDsAdHocFiltering,adhocFiltersInTooltips'
+      GF_FEATURE_TOGGLES_ENABLE: 'tableNextGen,queryLibrary,sqlExpressions,dashboardDsAdHocFiltering,adhocFiltersInTooltips,enableDashboardMigration'
     depends_on:
       - cube
 


### PR DESCRIPTION
Bump the default Grafana version from `12.3.3` to `main` in both
`docker-compose.yaml` and `.config/docker-compose-base.yaml`, and add
the `enableDashboardMigration` feature toggle.

Why: developing against the latest Grafana means we get the newest
features and surface breakages early. The existing ecom dashboards are
still in the v1 schema, but the `enableDashboardMigration` toggle lets
Grafana auto-migrate them to v2beta1 at render time, so we don't need
to update the JSON files in this PR — that can happen later.