### PR TITLE
fix: add dashboardNewLayouts feature toggle for dynamic dashboards

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana}
     environment:
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cubeds-ecom-full-data-model.json
-      GF_FEATURE_TOGGLES_ENABLE: 'tableNextGen,queryLibrary,sqlExpressions,dashboardDsAdHocFiltering,adhocFiltersInTooltips,enableDashboardMigration'
+      GF_FEATURE_TOGGLES_ENABLE: 'tableNextGen,queryLibrary,sqlExpressions,dashboardDsAdHocFiltering,adhocFiltersInTooltips,enableDashboardMigration,dashboardNewLayouts'
     depends_on:
       - cube
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the `dashboardNewLayouts` feature toggle to `docker-compose.yaml`, which removes the "The Dynamic Dashboard feature is temporarily disabled" warning banner on provisioned v2beta1 dashboards.

The `enableDashboardMigration` toggle alone converts dashboards to the new schema but doesn't enable the dynamic dashboard runtime. The `dashboardNewLayouts` toggle is required for Grafana to actually render v2beta1 dashboards as dynamic dashboards.

## Test plan

- [x] Both ecom dashboards render without the yellow warning banner
- [x] All dashboard panels continue to display data correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9088535-c93b-4045-8683-d7205ccdcb36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9088535-c93b-4045-8683-d7205ccdcb36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

