### PR TITLE
Add backend authorization for privileged CallResource routes

### DIFF
--- a/pkg/plugin/helpers_test.go
+++ b/pkg/plugin/helpers_test.go
@@ -16,6 +16,12 @@ func newTestPluginContext(url string) backend.PluginContext {
 	}
 }
 
+func newTestPluginContextWithUser(url string, role string) backend.PluginContext {
+	ctx := newTestPluginContext(url)
+	ctx.User = &backend.User{Role: role}
+	return ctx
+}
+
 func callHandler(t *testing.T, fn func(context.Context, *backend.CallResourceRequest, backend.CallResourceResponseSender) error, req *backend.CallResourceRequest) *backend.CallResourceResponse {
 	return callHandlerWithContext(context.Background(), t, fn, req)
 }

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -92,12 +92,29 @@ func (d *Datasource) CallResource(ctx context.Context, req *backend.CallResource
 	case "db-schema":
 		return d.handleDbSchema(ctx, req, sender)
 	case "generate-schema":
+		if !isAdmin(req) {
+			return sender.Send(accessDeniedResponse())
+		}
 		return d.handleGenerateSchema(ctx, req, sender)
 	default:
 		return sender.Send(&backend.CallResourceResponse{
 			Status: 404,
 			Body:   []byte(`{"error": "not found"}`),
 		})
+	}
+}
+
+func isAdmin(req *backend.CallResourceRequest) bool {
+	return req.PluginContext.User != nil && req.PluginContext.User.Role == "Admin"
+}
+
+func accessDeniedResponse() *backend.CallResourceResponse {
+	return &backend.CallResourceResponse{
+		Status: 403,
+		Body:   []byte(`{"error":"access denied"}`),
+		Headers: map[string][]string{
+			"Content-Type": {"application/json"},
+		},
 	}
 }
 

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -1705,7 +1705,7 @@ func TestCallResourceGenerateSchemaRouting(t *testing.T) {
 	}
 
 	req := &backend.CallResourceRequest{
-		PluginContext: newTestPluginContext(server.URL),
+		PluginContext: newTestPluginContextWithUser(server.URL, "Admin"),
 		Path:   "generate-schema",
 		Method: "POST",
 		Body:   requestBodyBytes,
@@ -1727,5 +1727,101 @@ func TestCallResourceGenerateSchemaRouting(t *testing.T) {
 
 	if len(generateSchemaResponse.Files) == 0 {
 		t.Errorf("Expected files to be present")
+	}
+}
+
+func TestCallResourceAuthorizationGenerateSchema(t *testing.T) {
+	upstreamCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"files":[]}`))
+	}))
+	defer server.Close()
+
+	body, _ := json.Marshal(GenerateSchemaRequest{
+		Format: "yaml",
+		Tables: [][]string{{"public", "t"}},
+	})
+
+	tests := []struct {
+		name           string
+		user           *backend.User
+		expectedStatus int
+	}{
+		{name: "nil user", user: nil, expectedStatus: 403},
+		{name: "Viewer", user: &backend.User{Role: "Viewer"}, expectedStatus: 403},
+		{name: "Editor", user: &backend.User{Role: "Editor"}, expectedStatus: 403},
+		{name: "Admin", user: &backend.User{Role: "Admin"}, expectedStatus: 200},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			upstreamCalled = false
+			ds := &Datasource{BaseURL: server.URL}
+
+			pCtx := newTestPluginContext(server.URL)
+			pCtx.User = tc.user
+
+			req := &backend.CallResourceRequest{
+				PluginContext: pCtx,
+				Path:          "generate-schema",
+				Method:        "POST",
+				Body:          body,
+			}
+
+			resp := callHandler(t, ds.CallResource, req)
+
+			if resp.Status != tc.expectedStatus {
+				t.Fatalf("Expected status %d, got %d (body: %s)", tc.expectedStatus, resp.Status, string(resp.Body))
+			}
+
+			if tc.expectedStatus == 403 && upstreamCalled {
+				t.Error("Denied request should not hit upstream Cube")
+			}
+		})
+	}
+}
+
+func TestCallResourceAuthorizationReadRoutes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/playground/files"):
+			_, _ = w.Write([]byte(`{"files":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/playground/db-schema"):
+			_, _ = w.Write([]byte(`{"tablesSchema":{}}`))
+		}
+	}))
+	defer server.Close()
+
+	routes := []string{"model-files", "db-schema"}
+
+	for _, route := range routes {
+		t.Run(route+" allows Viewer", func(t *testing.T) {
+			ds := &Datasource{BaseURL: server.URL}
+			req := &backend.CallResourceRequest{
+				PluginContext: newTestPluginContextWithUser(server.URL, "Viewer"),
+				Path:          route,
+				Method:        "GET",
+			}
+			resp := callHandler(t, ds.CallResource, req)
+			if resp.Status != 200 {
+				t.Fatalf("Expected 200 for %s with Viewer, got %d", route, resp.Status)
+			}
+		})
+
+		t.Run(route+" allows nil user", func(t *testing.T) {
+			ds := &Datasource{BaseURL: server.URL}
+			req := &backend.CallResourceRequest{
+				PluginContext: newTestPluginContext(server.URL),
+				Path:          route,
+				Method:        "GET",
+			}
+			resp := callHandler(t, ds.CallResource, req)
+			if resp.Status != 200 {
+				t.Fatalf("Expected 200 for %s with nil user, got %d", route, resp.Status)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

The Cube datasource backend exposes three `CallResource` routes for Data Model operations (`model-files`, `db-schema`, `generate-schema`) without explicit backend authorization checks. Today, any user who can reach `/api/datasources/uid/:uid/resources/...` (i.e. anyone with `datasources:query`) can call all three endpoints. This PR adds a backend authorization guard as defense in depth.

## Background

Grafana's HTTP API checks `datasources:query` at the route level before forwarding to a plugin's `CallResource` handler. There is no per-route differentiation — all resource endpoints share the same permission gate. This means the plugin itself must enforce any additional authorization boundaries.

The three Data Model routes have different risk profiles:

| Route | HTTP | What it does | Risk |
|-------|------|-------------|------|
| `model-files` | GET | Reads existing Cube model YAML files | Information disclosure (curated model) |
| `db-schema` | GET | Reads database table/column structure | Information disclosure (raw schema) |
| `generate-schema` | POST | Triggers Cube to generate new model files | Mutating operation on upstream Cube instance |

## Approach

We gate `generate-schema` behind an **Admin org role** check in the plugin backend. The read-only routes (`model-files`, `db-schema`) remain accessible to any user who passes Grafana's existing `datasources:query` check.

### Why Admin, not Editor?

In Grafana's default RBAC, `datasources:write` is granted to the **Admin** role only — Editors cannot edit datasource configs. Since `generate-schema` is a write/mutating operation, gating it on Admin aligns with the actual RBAC default. Using Editor as the threshold would over-permission Editors for an operation they don't have access to in Grafana's native permission model.

### Why org role instead of fine-grained RBAC?

The Grafana plugin SDK's `PluginContext.User` struct provides the user's org role (`Viewer`, `Editor`, `Admin`) but not their resolved RBAC permissions. Fine-grained RBAC checks via `authlib/authz` are currently only documented for app plugins (not datasource plugins), require the `externalServiceAccounts` feature toggle, and are limited to single-org setups. The org role check is a pragmatic first pass that covers the primary use cases.

### Direction of error

With the Admin threshold, we only err on the side of **too little** permission — a non-Admin who has been explicitly granted `datasources:write` via custom Enterprise RBAC would be denied. This is the safe direction and a rare edge case.

This is a temporary improvement which takes us in the right direction, and allows us more freedom to demo the Cube Datasource at GrafanaCon, including the schema / data model viewer and generator. We can improve on this further post-GrafanaCon.

### Anonymous users

Verified that anonymous users (e.g. on play.grafana.org) get `PluginContext.User` populated with `Role: "Viewer"` and empty Login/Name/Email. The guard correctly denies them access to `generate-schema`.

## Changes

- **`pkg/plugin/resources.go`** — Added `isAdmin()` guard on the `generate-schema` route in `CallResource`. Non-Admin callers receive `403 {"error":"access denied"}`. Added `accessDeniedResponse()` helper.
- **`pkg/plugin/helpers_test.go`** — Added `newTestPluginContextWithUser()` test helper.
- **`pkg/plugin/resources_test.go`** — Added `TestCallResourceAuthorizationGenerateSchema` (verifies nil/Viewer/Editor get 403, Admin gets 200, denied requests don't hit upstream Cube) and `TestCallResourceAuthorizationReadRoutes` (verifies `model-files` and `db-schema` remain accessible to Viewer and nil user). Updated existing `TestCallResourceGenerateSchemaRouting` to use Admin user.

## Unchanged routes

These are not gated (no change needed):
- `metadata` — query helper
- `tag-values` — query helper  
- `sql` — query helper

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new authorization gate on the mutating `generate-schema` resource route, which could block legitimate non-Admin callers depending on Grafana role/RBAC setup. Otherwise changes are localized and covered by new tests.
> 
> **Overview**
> Adds backend authorization for the privileged `generate-schema` `CallResource` route by requiring `PluginContext.User.Role == "Admin"`; non-admin (or nil user) requests now return `403` with a JSON `access denied` payload.
> 
> Updates and expands tests to exercise the new guard (including ensuring denied requests don’t hit the upstream Cube endpoint) while confirming read-only routes (`model-files`, `db-schema`) remain accessible, and adds a small test helper to build a plugin context with a user role.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 499504f8879c53f27fb7aae293b3474d99347c86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->