### PR TITLE
ci: fix CD workflow permissions and skip grafana-dev image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: read
       attestations: write
     with:
       branch: ${{ github.event.inputs.branch }}
@@ -46,6 +47,9 @@ jobs:
       # - 'universal': on-prem + cloud (default)
       # - 'grafana_cloud': cloud only, hidden for on-prem users
       scopes: universal
+
+      # Skip the grafana-dev image in Playwright E2E tests (image may be temporarily unavailable)
+      run-playwright-with-skip-grafana-dev-image: true
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to push.yaml:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs


### PR DESCRIPTION
## Summary

- Add `pull-requests: read` permission required by shared workflow `v6.1.1` (needed for its prod deployment safety check that blocks deploying branches with open PRs)
- Add `run-playwright-with-skip-grafana-dev-image: true` to match what `push.yaml` already has for CI, avoiding failures when the grafana-dev image is unavailable

Fixes the CD startup failure seen in [run #31](https://github.com/grafana/grafana-cube-datasource/actions/runs/23136060757).

## Test plan

- [x] Merge this PR
- [ ] Re-trigger CD workflow dispatch from main and verify it starts successfully

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CD workflow permissions and test execution flags in the release pipeline; misconfiguration could block deployments or mask E2E coverage, but scope is limited to GitHub Actions YAML.
> 
> **Overview**
> Updates the `publish.yaml` CD GitHub Actions workflow to grant `pull-requests: read` so the shared `plugin-ci-workflows` `cd.yml@v6.1.1` job can run its PR-related safety checks.
> 
> Also configures CD to pass `run-playwright-with-skip-grafana-dev-image: true`, matching CI, to avoid E2E failures when the `grafana-dev` image is unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54baaa2bdceac9c8c103847f60c14c4e0c81e6fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->