### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.3.1 (2026-03-20)
+
+### Security
+
+- **Backend authorization for generate-schema**: The mutating `generate-schema` CallResource route now requires Admin org role, preventing non-admin users from triggering model file generation on the upstream Cube instance (#216)
+
+### Improved
+
+- **Standard SQL casts**: Replace PostgreSQL-specific `::date` and `::numeric` cast syntax with standard `CAST()` in demo dashboard queries and Cube model, improving compatibility with DuckDB and BigQuery (#204)
+
+**Full Changelog**: [v0.3.0...v0.3.1](https://github.com/grafana/grafana-cube-datasource/compare/v0.3.0...v0.3.1)
+
 ## 0.3.0 (2026-03-13)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

Patch release to ship the backend authorization security fix and SQL portability improvements.

### Changes in v0.3.1

- **Security**: Backend authorization for `generate-schema` CallResource route — gates the mutating operation behind Admin org role (#216)
- **Improved**: Replace PostgreSQL-specific SQL casts with standard `CAST()` for cross-database compatibility (#204)

### Release checklist

- [x] Version bumped in `package.json` (`0.3.0` → `0.3.1`)
- [x] `CHANGELOG.md` updated
- [ ] CI passes
- [x] Merge PR
- [x] Tag `v0.3.1` on main and push tag


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only changes (changelog and version bumps) with no functional code modifications in this diff.
> 
> **Overview**
> Prepares the `v0.3.1` release by bumping the package version (`0.3.0` → `0.3.1`) and updating `CHANGELOG.md` to document the included security authorization tightening for `generate-schema` and SQL cast portability improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e30dcca9267dfee7603fd35715cb3459336f84a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->