### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,17 @@
 # Changelog
 
-## 0.3.1 (2026-03-20)
+## 0.3.2 (2026-03-20)
 
 ### Security
 
 - **Backend authorization for generate-schema**: The mutating `generate-schema` CallResource route now requires Admin org role, preventing non-admin users from triggering model file generation on the upstream Cube instance (#216)
+- **Dependency security fixes**: Update `flatted` to 3.4.2 to resolve CVE-2026-32141 and CVE-2026-33228
 
 ### Improved
 
 - **Standard SQL casts**: Replace PostgreSQL-specific `::date` and `::numeric` cast syntax with standard `CAST()` in demo dashboard queries and Cube model, improving compatibility with DuckDB and BigQuery (#204)
 
-**Full Changelog**: [v0.3.0...v0.3.1](https://github.com/grafana/grafana-cube-datasource/compare/v0.3.0...v0.3.1)
+**Full Changelog**: [v0.3.0...v0.3.2](https://github.com/grafana/grafana-cube-datasource/compare/v0.3.0...v0.3.2)
 
 ## 0.3.0 (2026-03-13)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
@@ -4246,9 +4246,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4266,9 +4263,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4286,9 +4280,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4306,9 +4297,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5341,9 +5329,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5358,9 +5343,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5375,9 +5357,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5392,9 +5371,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5409,9 +5385,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5426,9 +5399,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5443,9 +5413,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5460,9 +5427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8586,9 +8550,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/for-each": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

Re-release of v0.3.1 with a dependency fix. The v0.3.1 release workflow failed because `osv-scanner` flagged two high-severity CVEs in `flatted@3.3.3`.

### Changes since v0.3.1

- **Security**: Update `flatted` to 3.4.2 to resolve CVE-2026-32141 and CVE-2026-33228

### Changes since v0.3.0 (full release notes)

- **Security**: Backend authorization for `generate-schema` CallResource route (#216)
- **Security**: Update `flatted` to 3.4.2 (CVE-2026-32141, CVE-2026-33228)
- **Improved**: Replace PostgreSQL-specific SQL casts with standard `CAST()` (#204)

### Release checklist

- [x] Version bumped (`0.3.1` → `0.3.2`)
- [x] `CHANGELOG.md` updated
- [x] CI passes
- [x] Merge PR
- [x] Tag `v0.3.2` on main and push tag

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping plus a patch-level dependency bump (`flatted`), with no runtime logic changes beyond transitive package resolution.
> 
> **Overview**
> Releases **v0.3.2** by bumping the package version (`package.json`/`package-lock.json`) and updating the changelog.
> 
> Includes a security-focused dependency update: `flatted` is upgraded to `3.4.2` (via lockfile changes) to address CVE-2026-32141 and CVE-2026-33228, along with related `package-lock.json` metadata normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76dd8164ced6dc0ce8e7b1b65927f6c8c850387e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->