### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.3 (2026-03-20)
+
+### Bug Fixes
+
+- **Fix release build**: Remove Go source files shipped inside the `flatted` npm package (`golang/pkg/flatted/flatted.go`) via a `postinstall` script, preventing the Grafana plugin validator from rejecting the archive with "Invalid Go manifest file" (#2700)
+
+**Full Changelog**: [v0.3.2...v0.3.3](https://github.com/grafana/grafana-cube-datasource/compare/v0.3.2...v0.3.3)
+
 ## 0.3.2 (2026-03-20)
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "cube",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.3.2",
+      "version": "0.3.3",
+      "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
@@ -11,7 +11,8 @@
     "lint:fix": "npm run lint -- --fix && prettier --write --list-different .",
     "e2e": "playwright test",
     "server": "docker compose up --build",
-    "sign": "npx --yes @grafana/sign-plugin@latest"
+    "sign": "npx --yes @grafana/sign-plugin@latest",
+    "postinstall": "rm -rf node_modules/flatted/golang"
   },
   "author": "Grafana",
   "license": "AGPL-3.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-release of v0.3.2 with a build fix. The v0.3.1 and v0.3.2 release workflows both failed because the `flatted@3.4.2` npm package ships a Go implementation at `node_modules/flatted/golang/pkg/flatted/flatted.go`, and the Grafana plugin validator (`@grafana/plugin-validator`) rejects plugin archives containing `.go` files not listed in the Go build manifest.

### Changes since v0.3.2

- **Fix release build**: Add a `postinstall` script that removes `node_modules/flatted/golang` after `npm install`, preventing the Grafana plugin validator from finding stray Go source files in the source tree

### Release checklist

- [x] Version bumped (`0.3.2` → `0.3.3`)
- [x] `CHANGELOG.md` updated
- [ ] CI passes
- [ ] Merge PR
- [ ] Tag `v0.3.3` on main and push tag
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d04f7791-147a-4073-af7a-40793a806e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d04f7791-147a-4073-af7a-40793a806e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

