### PR TITLE
chore: regenerate package-lock.json to remove stale libc fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4249,9 +4249,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4269,9 +4266,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4289,9 +4283,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4309,9 +4300,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4329,9 +4317,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4349,9 +4334,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

- Removes stale `libc` array entries from optional native dependency lockfile entries that were dropped by a newer npm version
- Eliminates persistent local diff noise when running `npm install`

## Test plan

- [ ] CI passes (no functional changes)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only change that removes stale metadata from optional native `@swc/core` platform entries; no runtime code changes, with minimal risk beyond potential install reproducibility differences across npm versions.
> 
> **Overview**
> Regenerates `package-lock.json` to remove stale `libc` fields from optional native dependency entries (notably `@swc/core-*`), matching the output of newer npm versions.
> 
> This is intended to eliminate persistent local lockfile diffs after `npm install`, without changing application/runtime code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e553dea1d90cea15979414f3a7d61e8432447ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->