### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.0 (2026-03-27)
+
+### Features
+
+- **Measure/dimension descriptions in dropdowns**: Surface Cube field descriptions as subtitle text in the query editor's Dimensions and Measures dropdowns, with search matching against descriptions too (#235)
+- **Data Model tab hint after Save & Test**: Always show the Data Model configuration tab hint after a successful connection test, so new users discover model generation immediately (#189)
+
+**Full Changelog**: [v0.3.3...v0.4.0](https://github.com/grafana/grafana-cube-datasource/compare/v0.3.3...v0.4.0)
+
 ## 0.3.3 (2026-03-20)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

- Bump version to `0.4.0`
- Update CHANGELOG.md

## What's included

| Type | Description | PR |
|------|-------------|----|
| Feature | Surface Cube measure/dimension descriptions in query editor dropdowns | #235 |
| Feature | Always show Data Model tab hint after Save & Test | #189 |

## Release checklist

- [ ] CI passes
- [ ] Merge this PR
- [ ] Tag `v0.4.0` on main and push: `git checkout main && git pull && git tag v0.4.0 && git push origin v0.4.0`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release bookkeeping change (version bumps and changelog update) with no functional code modifications.
> 
> **Overview**
> Prepares the `v0.4.0` release by bumping the package version from `0.3.3` to `0.4.0` (including `package-lock.json`).
> 
> Updates `CHANGELOG.md` with the `0.4.0` entry, highlighting the new query-editor dropdown descriptions feature and the post-connection-test Data Model tab hint, plus the compare link for the release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4d9c89d19a39f23207302b58f48f75996cc3646. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->