### PR TITLE
refactor(metadata): only expose views, never fall back to cubes

### DIFF
--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -169,70 +169,54 @@ func (d *Datasource) handleMetadata(ctx context.Context, req *backend.CallResour
 	})
 }
 
-// extractMetadataFromResponse extracts dimensions and measures from Cube metadata
+// extractMetadataFromResponse extracts dimensions and measures from views only.
+// Cubes are internal implementation; views are the public API. If no views are
+// defined, an empty response is returned so the query editor can prompt the
+// user to create views rather than silently exposing raw cubes.
 func (d *Datasource) extractMetadataFromResponse(metaResponse *CubeMetaResponse) MetadataResponse {
 	var dimensions []SelectOption
 	var measures []SelectOption
 
-	// Filter to only include views from the cubes array
-	var views []CubeMeta
-	var cubes []CubeMeta
-	for _, cube := range metaResponse.Cubes {
-		if cube.Type == "view" {
-			views = append(views, cube)
-		} else {
-			cubes = append(cubes, cube)
-		}
-	}
-
-	// Use views if available (they represent the curated data model), otherwise fall back to cubes
-	var itemsToProcess []CubeMeta
-	if len(views) > 0 {
-		itemsToProcess = views
-		backend.Logger.Debug("Using views for metadata", "viewCount", len(views))
-	} else {
-		itemsToProcess = cubes
-		backend.Logger.Debug("Using cubes for metadata (no views found)", "cubeCount", len(cubes))
-	}
-
-	// Track processed items to avoid duplicates
 	processedDimensions := make(map[string]bool)
 	processedMeasures := make(map[string]bool)
 
-	// Iterate through views/cubes and collect dimensions and measures
-	for _, item := range itemsToProcess {
-		// Collect dimensions
-		for _, dimension := range item.Dimensions {
+	viewCount := 0
+	for _, cube := range metaResponse.Cubes {
+		if cube.Type != "view" {
+			continue
+		}
+		viewCount++
+
+		for _, dimension := range cube.Dimensions {
 			if !processedDimensions[dimension.Name] {
 				dimensions = append(dimensions, SelectOption{
 					Label:              dimension.Name,
 					Value:              dimension.Name,
 					Type:               dimension.Type,
 					Description:        dimension.Description,
-					Cube:               item.Name,
-					ConnectedComponent: item.ConnectedComponent,
+					Cube:               cube.Name,
+					ConnectedComponent: cube.ConnectedComponent,
 				})
 				processedDimensions[dimension.Name] = true
 			}
 		}
 
-		// Collect measures
-		for _, measure := range item.Measures {
+		for _, measure := range cube.Measures {
 			if !processedMeasures[measure.Name] {
 				measures = append(measures, SelectOption{
 					Label:              measure.Name,
 					Value:              measure.Name,
 					Type:               measure.Type,
 					Description:        measure.Description,
-					Cube:               item.Name,
-					ConnectedComponent: item.ConnectedComponent,
+					Cube:               cube.Name,
+					ConnectedComponent: cube.ConnectedComponent,
 				})
 				processedMeasures[measure.Name] = true
 			}
 		}
 	}
 
-	backend.Logger.Debug("Extracted metadata", "dimensions", len(dimensions), "measures", len(measures))
+	backend.Logger.Debug("Extracted metadata from views", "views", viewCount, "dimensions", len(dimensions), "measures", len(measures))
 
 	return MetadataResponse{
 		Dimensions: dimensions,

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -1318,36 +1318,35 @@ func TestHandleDbSchemaWithMissingURL(t *testing.T) {
 }
 
 func TestExtractMetadataPropagatesCubeAndConnectedComponent(t *testing.T) {
-	// When Cube reports cubes belonging to different connected components
-	// (i.e. cubes that cannot be joined together), each emitted SelectOption
-	// must carry the Cube name and ConnectedComponent so the frontend can
-	// disable cross-component options once a selection has been made.
+	// Views belonging to different connected components must carry the
+	// view name and ConnectedComponent so the frontend can disable
+	// cross-component options once a selection has been made.
 	ds := &Datasource{}
 
 	metaResponse := &CubeMetaResponse{
 		Cubes: []CubeMeta{
 			{
-				Name:               "orders",
-				Title:              "Orders",
-				Type:               "cube",
+				Name:               "order_overview",
+				Title:              "Order Overview",
+				Type:               "view",
 				ConnectedComponent: 1,
 				Dimensions: []CubeDimension{
-					{Name: "orders.status", Type: "string"},
+					{Name: "order_overview.status", Type: "string"},
 				},
 				Measures: []CubeMeasure{
-					{Name: "orders.count", Type: "number"},
+					{Name: "order_overview.count", Type: "number"},
 				},
 			},
 			{
-				Name:               "marketing_events",
-				Title:              "Marketing Events",
-				Type:               "cube",
+				Name:               "marketing_overview",
+				Title:              "Marketing Overview",
+				Type:               "view",
 				ConnectedComponent: 2,
 				Dimensions: []CubeDimension{
-					{Name: "marketing_events.channel", Type: "string"},
+					{Name: "marketing_overview.channel", Type: "string"},
 				},
 				Measures: []CubeMeasure{
-					{Name: "marketing_events.count", Type: "number"},
+					{Name: "marketing_overview.count", Type: "number"},
 				},
 			},
 		},
@@ -1355,7 +1354,6 @@ func TestExtractMetadataPropagatesCubeAndConnectedComponent(t *testing.T) {
 
 	result := ds.extractMetadataFromResponse(metaResponse)
 
-	// Build lookup maps so we don't depend on ordering.
 	dimsByValue := make(map[string]SelectOption, len(result.Dimensions))
 	for _, d := range result.Dimensions {
 		dimsByValue[d.Value] = d
@@ -1371,10 +1369,10 @@ func TestExtractMetadataPropagatesCubeAndConnectedComponent(t *testing.T) {
 		cube               string
 		connectedComponent int
 	}{
-		{dimsByValue, "orders.status", "orders", 1},
-		{dimsByValue, "marketing_events.channel", "marketing_events", 2},
-		{measuresByValue, "orders.count", "orders", 1},
-		{measuresByValue, "marketing_events.count", "marketing_events", 2},
+		{dimsByValue, "order_overview.status", "order_overview", 1},
+		{dimsByValue, "marketing_overview.channel", "marketing_overview", 2},
+		{measuresByValue, "order_overview.count", "order_overview", 1},
+		{measuresByValue, "marketing_overview.count", "marketing_overview", 2},
 	}
 
 	for _, e := range expectations {
@@ -1392,8 +1390,7 @@ func TestExtractMetadataPropagatesCubeAndConnectedComponent(t *testing.T) {
 	}
 
 	// Round-trip through JSON to verify the field names match what the
-	// frontend expects (cube, connectedComponent), since changing those
-	// would silently break the wire contract.
+	// frontend expects (cube, connectedComponent).
 	body, err := json.Marshal(result)
 	if err != nil {
 		t.Fatalf("failed to marshal metadata response: %v", err)
@@ -1414,6 +1411,54 @@ func TestExtractMetadataPropagatesCubeAndConnectedComponent(t *testing.T) {
 	}
 	if _, ok := first["connectedComponent"]; !ok {
 		t.Errorf("expected dimension JSON to include 'connectedComponent' key, got %v", first)
+	}
+}
+
+func TestExtractMetadataIgnoresCubesWithoutViews(t *testing.T) {
+	// When the response contains only cubes (no views), the metadata should
+	// be empty — cubes are internal implementation and must not leak through.
+	ds := &Datasource{}
+
+	metaResponse := &CubeMetaResponse{
+		Cubes: []CubeMeta{
+			{
+				Name:  "orders",
+				Title: "Orders",
+				Type:  "cube",
+				Dimensions: []CubeDimension{
+					{Name: "orders.status", Type: "string"},
+				},
+				Measures: []CubeMeasure{
+					{Name: "orders.count", Type: "number"},
+				},
+			},
+		},
+	}
+
+	result := ds.extractMetadataFromResponse(metaResponse)
+
+	if len(result.Dimensions) != 0 {
+		t.Errorf("expected 0 dimensions when only cubes present, got %d", len(result.Dimensions))
+	}
+	if len(result.Measures) != 0 {
+		t.Errorf("expected 0 measures when only cubes present, got %d", len(result.Measures))
+	}
+}
+
+func TestExtractMetadataEmptyResponse(t *testing.T) {
+	ds := &Datasource{}
+
+	metaResponse := &CubeMetaResponse{
+		Cubes: []CubeMeta{},
+	}
+
+	result := ds.extractMetadataFromResponse(metaResponse)
+
+	if len(result.Dimensions) != 0 {
+		t.Errorf("expected 0 dimensions for empty response, got %d", len(result.Dimensions))
+	}
+	if len(result.Measures) != 0 {
+		t.Errorf("expected 0 measures for empty response, got %d", len(result.Measures))
 	}
 }
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -159,9 +159,21 @@ function VisualQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
     return selectedFields.map((field) => ({ label: field.split('.').pop() || field, value: field }));
   }, [query.dimensions, query.measures]);
 
+  const hasNoViews =
+    !metadataIsLoading && !metadataIsError && metadata.dimensions.length === 0 && metadata.measures.length === 0;
+
   return (
     <>
       {metadataIsError && <Alert title="Error fetching metadata" severity="error" />}
+      {hasNoViews && (
+        <Alert title="No views found" severity="info">
+          Define{' '}
+          <TextLink href="https://cube.dev/docs/product/data-modeling/concepts/data-model-syntax#views" external>
+            views
+          </TextLink>{' '}
+          in your Cube data model to expose dimensions and measures.
+        </Alert>
+      )}
       <InlineField label="Dimensions" labelWidth={16} tooltip="Select the dimensions to group your data by" grow>
         <div className={styles.multiSelectWrapper}>
           <div className={styles.multiSelectContainer}>


### PR DESCRIPTION
## Summary

- Removes the cube fallback in `extractMetadataFromResponse` — the datasource now only returns metadata from Cube views, never raw cubes
- When no views are defined, the metadata response is empty (no dimensions, no measures) instead of silently exposing cubes that would vanish the moment someone adds the first view
- Adds an informative "No views found" hint in the query editor when metadata is empty, linking to the Cube views documentation

## Why

The previous fallback created a confusing failure mode: everything worked fine with cubes-only until someone added the first view, at which point all viewless cubes silently disappeared from the picker. Failing visibly (empty metadata + hint) is better than failing silently. This also aligns with Cube's own direction — views are the public API, cubes are implementation.

## Test plan

- [x] `TestExtractMetadataFromResponse` — views-only input returns correct dimensions/measures
- [x] `TestHandleMetadata` — end-to-end: views used, cubes ignored when both present
- [x] `TestExtractMetadataPropagatesCubeAndConnectedComponent` — updated to use views, verifies cube/connectedComponent propagation
- [x] `TestExtractMetadataIgnoresCubesWithoutViews` — **new**: cubes-only response returns empty metadata
- [x] `TestExtractMetadataEmptyResponse` — **new**: empty Cubes array returns empty metadata
- [ ] Manual: verify "No views found" alert renders in the query editor when no views exist

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the metadata contract and query editor behavior by returning view-only fields and adding join-graph (connected component) enforcement, which could impact existing instances relying on cube fallback or older Cube meta payloads.
> 
> **Overview**
> The datasource `metadata` response now **only includes Cube `view` fields**; the previous fallback that exposed raw `cube` dimensions/measures has been removed, so cubes-only models return an empty metadata list.
> 
> Metadata options now include `cube` and `connectedComponent` (propagated from `/v1/meta`), and the query editor uses this to **disable non-joinable fields** (cross-component) with an explanatory description. When metadata is empty (no views), the UI shows a **"No views found"** info alert linking to Cube docs.
> 
> Adds backend and frontend tests for view-only behavior, empty-metadata cases, and joinability-based disabling, plus a new `utils/joinability` helper to derive and apply the disabled-state decoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985f980988c5097bd74af4b2e2341d6470eecf21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->