### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0 (2026-05-01)
+
+### Features
+
+- **View-scoped visual queries**: The visual query builder now scopes to one Cube view at a time, treating views as the curated public query surface. Fields from other views are disabled with guidance to model cross-view combinations as a new view. The `/metadata` resource now exposes only view members (#304)
+
+**Full Changelog**: [v0.4.0...v0.5.0](https://github.com/grafana/grafana-cube-datasource/compare/v0.4.0...v0.5.0)
+
 ## 0.4.0 (2026-03-27)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cube",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cube",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## Summary

- Bump version to `0.5.0`
- Update CHANGELOG.md

## What's included

| Type | Description | PR |
|------|-------------|-----|
| Feature | View-scoped visual queries: scope the query builder to one Cube view at a time | #304 |

## Release checklist

- [x] CI passes
- [x] Merge this PR
- [ ] Tag `v0.5.0` on main and push: `git checkout main && git pull && git tag v0.5.0 && git push origin v0.5.0`
- [ ] Run CD workflow: dev -> ops -> prod-canary -> prod


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version numbers and changelog text are updated, with no runtime code changes.
> 
> **Overview**
> Bumps the plugin version from `0.4.0` to `0.5.0` in `package.json` and `package-lock.json`.
> 
> Updates `CHANGELOG.md` with the `0.5.0` release notes (view-scoped visual queries) and the compare link for `v0.4.0...v0.5.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29995c2331d240187e695e4b1211ca1833c09533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->