### PR TITLE
chore: add release skill for Cursor agent

### DIFF
--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -13,6 +13,26 @@ description: >-
 Full release lifecycle for `grafana/grafana-cube-datasource`. Covers babysitting
 a PR, creating a release PR, tagging, and CD deployment.
 
+**Run locally.** This skill requires local credentials (GPG tag signing via
+1Password, `gcom-ops` auth) that are not available in cloud agents. It is safe
+to run as a background agent -- all git operations use an isolated worktree so
+they won't interfere with the user's working tree.
+
+## Worktree setup
+
+All git operations (Phases 2–3) run in a temporary worktree to avoid disrupting
+the user's checkout. Create it at the start and clean it up at the end:
+
+```bash
+git worktree add /tmp/cube-ds-release main
+```
+
+Run Phase 2 and Phase 3 commands inside `/tmp/cube-ds-release`. When finished:
+
+```bash
+git worktree remove /tmp/cube-ds-release
+```
+
 ## Phase 1 — Babysit & merge the feature PR
 
 If the user provides a PR to babysit before releasing:
@@ -25,14 +45,21 @@ If the user provides a PR to babysit before releasing:
    `gh run view <run-id> --repo grafana/grafana-cube-datasource --log-failed`
 4. Once green + mergeable, merge with squash and delete the remote branch:
    `gh pr merge <PR> --repo grafana/grafana-cube-datasource --squash --delete-branch`
-5. Switch to main and pull: `git checkout main && git pull`
-6. Delete local branches for the merged PR and any predecessor PRs the user
+5. Delete local branches for the merged PR and any predecessor PRs the user
    mentions: `git branch -D <branch> ...`
-7. Prune stale remote-tracking refs: `git fetch --prune origin`
+6. Prune stale remote-tracking refs: `git fetch --prune origin`
 
 ## Phase 2 — Create the release PR
 
-1. **Determine the version bump.** Review commits since the last tag:
+Work inside the worktree (`/tmp/cube-ds-release`).
+
+1. **Pull latest main:**
+
+   ```bash
+   cd /tmp/cube-ds-release && git pull
+   ```
+
+2. **Determine the version bump.** Review commits since the last tag:
 
    ```
    git log $(git describe --tags --abbrev=0)..HEAD --oneline
@@ -44,14 +71,14 @@ If the user provides a PR to babysit before releasing:
 
    Ask the user to confirm the version if unsure.
 
-2. **Create the release branch and bump:**
+3. **Create the release branch and bump:**
 
-   ```
+   ```bash
    git checkout -b sj/release/v<VERSION>
    npm version <patch|minor|major> --no-git-tag-version
    ```
 
-3. **Update `CHANGELOG.md`.** Prepend a new section after `# Changelog`:
+4. **Update `CHANGELOG.md`.** Prepend a new section after `# Changelog`:
 
    ```markdown
    ## <VERSION> (<YYYY-MM-DD>)
@@ -66,9 +93,9 @@ If the user provides a PR to babysit before releasing:
    Only list user-facing changes (features, fixes, security, deprecations).
    Skip dependency bumps unless they fix a CVE worth calling out.
 
-4. **Commit, push, and open the PR:**
+5. **Commit, push, and open the PR:**
 
-   ```
+   ```bash
    git add package.json package-lock.json CHANGELOG.md
    git commit -m "chore: release v<VERSION>"
    git push -u origin HEAD
@@ -78,16 +105,17 @@ If the user provides a PR to babysit before releasing:
    PR body should include a summary table of what's included and a release
    checklist (CI, merge, tag, CD).
 
-5. **Babysit the release PR** using the same polling loop from Phase 1.
+6. **Babysit the release PR** using the same polling loop from Phase 1.
 
-6. **Merge** when green:
+7. **Merge** when green:
    `gh pr merge <PR> --repo grafana/grafana-cube-datasource --squash --delete-branch`
 
 ## Phase 3 — Tag & push
 
-After the release PR is merged:
+Still inside the worktree:
 
-```
+```bash
+cd /tmp/cube-ds-release
 git checkout main && git pull
 git tag v<VERSION>
 git push origin v<VERSION>
@@ -108,6 +136,12 @@ Then publish the draft release:
 
 ```
 gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --draft=false
+```
+
+**Clean up the worktree** now that git operations are done:
+
+```bash
+git worktree remove /tmp/cube-ds-release
 ```
 
 ## Phase 4 — CD deployment
@@ -163,6 +197,5 @@ gcom-ops /instances/ops/restart -d 'reason=SamJ here- bump Cube DS to version <V
 
 ## Post-release
 
-- Clean up the local release branch: `git branch -d sj/release/v<VERSION>`
 - Verify the plugin version is live: check the
   [Grafana plugin catalog](https://grafana.com/grafana/plugins/grafana-cube-datasource/)

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -21,10 +21,13 @@ they won't interfere with the user's working tree.
 ## Worktree setup
 
 All git operations (Phases 2–3) run in a temporary worktree to avoid disrupting
-the user's checkout. Create it at the start and clean it up at the end:
+the user's checkout. Create it at the start and clean it up at the end. Use
+`--detach` so the worktree doesn't try to claim the `main` branch (which is
+likely already checked out in the user's primary worktree — Git forbids the
+same branch being checked out twice):
 
 ```bash
-git worktree add /tmp/cube-ds-release main
+git worktree add --detach /tmp/cube-ds-release main
 ```
 
 Run Phase 2 and Phase 3 commands inside `/tmp/cube-ds-release`. When finished:
@@ -53,10 +56,11 @@ If the user provides a PR to babysit before releasing:
 
 Work inside the worktree (`/tmp/cube-ds-release`).
 
-1. **Pull latest main:**
+1. **Sync to latest main.** The worktree is detached, so `git pull` won't work
+   — fetch and re-point HEAD instead:
 
    ```bash
-   cd /tmp/cube-ds-release && git pull
+   cd /tmp/cube-ds-release && git fetch origin && git checkout --detach origin/main
    ```
 
 2. **Determine the version bump.** Review commits since the last tag:
@@ -112,11 +116,13 @@ Work inside the worktree (`/tmp/cube-ds-release`).
 
 ## Phase 3 — Tag & push
 
-Still inside the worktree:
+Still inside the worktree. Re-point the detached HEAD to the freshly merged
+`main` (don't use `git checkout main` — `main` is checked out in the user's
+primary worktree):
 
 ```bash
 cd /tmp/cube-ds-release
-git checkout main && git pull
+git fetch origin && git checkout --detach origin/main
 git tag v<VERSION>
 git push origin v<VERSION>
 ```

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: grafana-plugin-release
+description: >-
+  Release the Grafana Cube datasource plugin end-to-end: babysit a feature PR
+  until green and merge it, create and merge a release PR (version bump +
+  changelog), tag the release, and run the CD workflow through all environments.
+  Use when the user mentions release, publish, ship, deploy the plugin, or
+  babysit a PR.
+---
+
+# Grafana Plugin Release
+
+Full release lifecycle for `grafana/grafana-cube-datasource`. Covers babysitting
+a PR, creating a release PR, tagging, and CD deployment.
+
+## Phase 1 — Babysit & merge the feature PR
+
+If the user provides a PR to babysit before releasing:
+
+1. Poll CI with `gh pr checks <PR> --repo grafana/grafana-cube-datasource`
+   every 60–90s until all checks resolve.
+2. Triage any Bugbot or reviewer comments — fix what you agree with, explain
+   when you disagree.
+3. If a check **fails**, investigate the logs:
+   `gh run view <run-id> --repo grafana/grafana-cube-datasource --log-failed`
+4. Once green + mergeable, merge with squash and delete the remote branch:
+   `gh pr merge <PR> --repo grafana/grafana-cube-datasource --squash --delete-branch`
+5. Switch to main and pull: `git checkout main && git pull`
+6. Delete local branches for the merged PR and any predecessor PRs the user
+   mentions: `git branch -D <branch> ...`
+7. Prune stale remote-tracking refs: `git fetch --prune origin`
+
+## Phase 2 — Create the release PR
+
+1. **Determine the version bump.** Review commits since the last tag:
+
+   ```
+   git log $(git describe --tags --abbrev=0)..HEAD --oneline
+   ```
+
+   - New features → `minor`
+   - Bug fixes only → `patch`
+   - Breaking changes → `major`
+
+   Ask the user to confirm the version if unsure.
+
+2. **Create the release branch and bump:**
+
+   ```
+   git checkout -b sj/release/v<VERSION>
+   npm version <patch|minor|major> --no-git-tag-version
+   ```
+
+3. **Update `CHANGELOG.md`.** Prepend a new section after `# Changelog`:
+
+   ```markdown
+   ## <VERSION> (<YYYY-MM-DD>)
+
+   ### Features | Bug Fixes | Security | Breaking Changes
+
+   - **Short bold title**: Description (#PR)
+
+   **Full Changelog**: [v<PREV>...v<VERSION>](https://github.com/grafana/grafana-cube-datasource/compare/v<PREV>...v<VERSION>)
+   ```
+
+   Only list user-facing changes (features, fixes, security, deprecations).
+   Skip dependency bumps unless they fix a CVE worth calling out.
+
+4. **Commit, push, and open the PR:**
+
+   ```
+   git add package.json package-lock.json CHANGELOG.md
+   git commit -m "chore: release v<VERSION>"
+   git push -u origin HEAD
+   gh pr create --title "chore: release v<VERSION>" --body "..."
+   ```
+
+   PR body should include a summary table of what's included and a release
+   checklist (CI, merge, tag, CD).
+
+5. **Babysit the release PR** using the same polling loop from Phase 1.
+
+6. **Merge** when green:
+   `gh pr merge <PR> --repo grafana/grafana-cube-datasource --squash --delete-branch`
+
+## Phase 3 — Tag & push
+
+After the release PR is merged:
+
+```
+git checkout main && git pull
+git tag v<VERSION>
+git push origin v<VERSION>
+```
+
+This triggers `.github/workflows/release.yml` which:
+- Builds and signs the plugin for all platforms
+- Creates a **draft** GitHub release with artifacts and SHA checksums
+- Generates provenance attestation
+
+Verify the release workflow completes:
+
+```
+gh run list --workflow=release.yml --limit 1 --repo grafana/grafana-cube-datasource
+```
+
+Then publish the draft release:
+
+```
+gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --draft=false
+```
+
+## Phase 4 — CD deployment
+
+The CD workflow (`.github/workflows/publish.yaml`) publishes to the Grafana
+plugin catalog. It is triggered via `workflow_dispatch`. Each environment is
+an independent run (they don't bundle each other).
+
+Available environments: `dev`, `ops`, `prod-canary`, `prod`.
+
+**Default: deploy straight to prod.** While the plugin is experimental and
+moving fast, skip the staged rollout and go directly to prod:
+
+```bash
+gh workflow run publish.yaml --repo grafana/grafana-cube-datasource \
+  -f branch=main -f environment=prod
+```
+
+If the user wants a staged rollout instead, deploy through environments in
+order (dev -> ops -> prod-canary -> prod), confirming each succeeds before
+proceeding.
+
+Poll the run with:
+
+```
+gh run list --workflow=publish.yaml --limit 1 --repo grafana/grafana-cube-datasource --json status,conclusion,displayTitle
+```
+
+Wait for `"status": "completed"` and `"conclusion": "success"`.
+
+## Post-release
+
+- Clean up the local release branch: `git branch -d sj/release/v<VERSION>`
+- Verify the plugin version is live: check the
+  [Grafana plugin catalog](https://grafana.com/grafana/plugins/grafana-cube-datasource/)

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -138,6 +138,29 @@ gh run list --workflow=publish.yaml --limit 1 --repo grafana/grafana-cube-dataso
 
 Wait for `"status": "completed"` and `"conclusion": "success"`.
 
+## Phase 5 — Update internal Grafana instances
+
+After the catalog publish completes, bump the plugin on the internal Grafana
+Cloud instances and restart them. Use `gcom-ops` from the sibling
+`deployment_tools` repo (`../deployment_tools/scripts/gcom/gcom-ops`), or a
+local alias if available.
+
+Update each instance to the latest catalog version:
+
+```bash
+gcom-ops /instances/bidev/plugins/grafana-cube-datasource -dversion=latest
+gcom-ops /instances/bi/plugins/grafana-cube-datasource -dversion=latest
+gcom-ops /instances/ops/plugins/grafana-cube-datasource -dversion=latest
+```
+
+Then restart each instance so the new version takes effect:
+
+```bash
+gcom-ops /instances/bidev/restart -d 'reason=SamJ here- bump Cube DS to version <VERSION>'
+gcom-ops /instances/bi/restart -d 'reason=SamJ here- bump Cube DS to version <VERSION>'
+gcom-ops /instances/ops/restart -d 'reason=SamJ here- bump Cube DS to version <VERSION>'
+```
+
 ## Post-release
 
 - Clean up the local release branch: `git branch -d sj/release/v<VERSION>`

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -74,7 +74,7 @@ Work inside the worktree (`/tmp/cube-ds-release`).
 3. **Create the release branch and bump:**
 
    ```bash
-   git checkout -b sj/release/v<VERSION>
+   git checkout -b release/v<VERSION>
    npm version <patch|minor|major> --no-git-tag-version
    ```
 
@@ -190,9 +190,9 @@ gcom-ops /instances/ops/plugins/grafana-cube-datasource -dversion=latest
 Then restart each instance so the new version takes effect:
 
 ```bash
-gcom-ops /instances/bidev/restart -d 'reason=SamJ here- bump Cube DS to version <VERSION>'
-gcom-ops /instances/bi/restart -d 'reason=SamJ here- bump Cube DS to version <VERSION>'
-gcom-ops /instances/ops/restart -d 'reason=SamJ here- bump Cube DS to version <VERSION>'
+gcom-ops /instances/bidev/restart -d 'reason=bump Cube DS to version <VERSION>'
+gcom-ops /instances/bi/restart -d 'reason=bump Cube DS to version <VERSION>'
+gcom-ops /instances/ops/restart -d 'reason=bump Cube DS to version <VERSION>'
 ```
 
 ## Post-release


### PR DESCRIPTION
## Summary

- Adds a Cursor agent skill at `.cursor/skills/release/SKILL.md` that documents the end-to-end plugin release lifecycle
- Covers: babysit & merge a feature PR, create a release PR (version bump + changelog), tag, GitHub release, and CD deployment


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation-only Cursor skill content; no runtime or production code paths are modified.
> 
> **Overview**
> Adds a new Cursor agent skill at `.cursor/skills/release/SKILL.md` that documents the end-to-end release process for `grafana/grafana-cube-datasource`.
> 
> The guide covers PR babysitting/merging, creating a release PR (version bump + `CHANGELOG.md` updates), tagging/publishing a GitHub release, triggering CD via `publish.yaml`, and post-release internal instance updates, with worktree-based git steps to avoid disrupting the user checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b47fd7829ff57e8af10549107d276ed058e0a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->