### PR TITLE
docs(release skill): scrub internal references from public skill

### DIFF
--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -13,10 +13,10 @@ description: >-
 Full release lifecycle for `grafana/grafana-cube-datasource`. Covers babysitting
 a PR, creating a release PR, tagging, and CD deployment.
 
-**Run locally.** This skill requires local credentials (GPG tag signing via
-1Password, `gcom-ops` auth) that are not available in cloud agents. It is safe
-to run as a background agent -- all git operations use an isolated worktree so
-they won't interfere with the user's working tree.
+**Run locally.** This skill requires local credentials (GPG tag signing,
+internal post-publish tooling) that are not available in cloud agents. It is
+safe to run as a background agent -- all git operations use an isolated
+worktree so they won't interfere with the user's working tree.
 
 ## Worktree setup
 
@@ -178,28 +178,10 @@ gh run list --workflow=publish.yaml --limit 1 --repo grafana/grafana-cube-dataso
 
 Wait for `"status": "completed"` and `"conclusion": "success"`.
 
-## Phase 5 — Update internal Grafana instances
+## Phase 5 — Internal post-publish steps
 
-After the catalog publish completes, bump the plugin on the internal Grafana
-Cloud instances and restart them. Use `gcom-ops` from the sibling
-`deployment_tools` repo (`../deployment_tools/scripts/gcom/gcom-ops`), or a
-local alias if available.
-
-Update each instance to the latest catalog version:
-
-```bash
-gcom-ops /instances/bidev/plugins/grafana-cube-datasource -dversion=latest
-gcom-ops /instances/bi/plugins/grafana-cube-datasource -dversion=latest
-gcom-ops /instances/ops/plugins/grafana-cube-datasource -dversion=latest
-```
-
-Then restart each instance so the new version takes effect:
-
-```bash
-gcom-ops /instances/bidev/restart -d 'reason=bump Cube DS to version <VERSION>'
-gcom-ops /instances/bi/restart -d 'reason=bump Cube DS to version <VERSION>'
-gcom-ops /instances/ops/restart -d 'reason=bump Cube DS to version <VERSION>'
-```
+After the catalog publish completes, follow the internal post-publish runbook
+to bump the plugin on the relevant Grafana Cloud instances and restart them.
 
 ## Post-release
 


### PR DESCRIPTION
## Summary

Removes internal-only details from the release skill that don't belong in a public repo. Follow-up to #306.

Specifically scrubs:
- The `gcom-ops` commands and their flags
- Internal Grafana Cloud instance slugs
- Reference to the internal monorepo and its directory structure
- Mention of the GPG signing backend

Phase 5 now points at the internal post-publish runbook generically. The detailed commands live in the corresponding skill in the internal repo, which will follow in a separate PR there.

## Why

The original PR shipped these references publicly. None of it is a credential or directly exploitable, but it's recon material that doesn't need to be in an open-source repo. Sanitising the public copy now stops it being indexed/re-scraped going forward.

## Test plan

- [ ] CI passes
- [ ] Diff reviewed for any remaining internal references

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that removes internal operational details and replaces them with a generic runbook reference; no runtime or release automation code is affected.
> 
> **Overview**
> Updates the `grafana-plugin-release` skill documentation to **scrub internal-only operational references**.
> 
> Replaces explicit Phase 5 instructions (including `gcom-ops` commands, internal instance identifiers, and related tooling references) with a generic pointer to an internal post-publish runbook, and generalizes the local-credentials note to avoid internal specifics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2034df6123450d95f2b769c074d691b048628b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->