### PR TITLE
ci: automate version bumps & enforce conventional commits

### DIFF
--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -2,8 +2,8 @@
 name: grafana-plugin-release
 description: >-
   Release the Grafana Cube datasource plugin end-to-end: babysit a feature PR
-  until green and merge it, create and merge a release PR (version bump +
-  changelog), tag the release, and run the CD workflow through all environments.
+  until green and merge it, trigger the version-bump-changelog workflow to
+  publish a release, and run the CD workflow to deploy to Grafana Cloud.
   Use when the user mentions release, publish, ship, deploy the plugin, or
   babysit a PR.
 ---
@@ -11,30 +11,13 @@ description: >-
 # Grafana Plugin Release
 
 Full release lifecycle for `grafana/grafana-cube-datasource`. Covers babysitting
-a PR, creating a release PR, tagging, and CD deployment.
+a feature PR, cutting a release via the automated version-bump workflow, and
+deploying via the CD workflow.
 
-**Run locally.** This skill requires local credentials (GPG tag signing,
-internal post-publish tooling) that are not available in cloud agents. It is
-safe to run as a background agent -- all git operations use an isolated
-worktree so they won't interfere with the user's working tree.
-
-## Worktree setup
-
-All git operations (Phases 2–3) run in a temporary worktree to avoid disrupting
-the user's checkout. Create it at the start and clean it up at the end. Use
-`--detach` so the worktree doesn't try to claim the `main` branch (which is
-likely already checked out in the user's primary worktree — Git forbids the
-same branch being checked out twice):
-
-```bash
-git worktree add --detach /tmp/cube-ds-release main
-```
-
-Run Phase 2 and Phase 3 commands inside `/tmp/cube-ds-release`. When finished:
-
-```bash
-git worktree remove /tmp/cube-ds-release
-```
+The version bump, `CHANGELOG.md` generation and tag push all happen in CI via
+the `Version bump, changelog` workflow — there are no local `git`, `npm` or
+worktree commands to run. The only local credential needed is `gh` auth to
+trigger the workflows.
 
 ## Phase 1 — Babysit & merge the feature PR
 
@@ -46,111 +29,70 @@ If the user provides a PR to babysit before releasing:
    when you disagree.
 3. If a check **fails**, investigate the logs:
    `gh run view <run-id> --repo grafana/grafana-cube-datasource --log-failed`
-4. Once green + mergeable, merge with squash and delete the remote branch:
+4. PR titles must follow conventional commits (`feat:`, `fix:`, `chore:`, …) —
+   the `Conventional Commits` check enforces this and the prefix decides the
+   `CHANGELOG.md` section the change is filed under. Fix the title with
+   `gh pr edit <PR> --title "..."` if it fails.
+5. Once green + mergeable, merge with squash and delete the remote branch:
    `gh pr merge <PR> --repo grafana/grafana-cube-datasource --squash --delete-branch`
-5. Delete local branches for the merged PR and any predecessor PRs the user
+6. Delete local branches for the merged PR and any predecessor PRs the user
    mentions: `git branch -D <branch> ...`
-6. Prune stale remote-tracking refs: `git fetch --prune origin`
+7. Prune stale remote-tracking refs: `git fetch --prune origin`
 
-## Phase 2 — Create the release PR
+## Phase 2 — Cut the release
 
-Work inside the worktree (`/tmp/cube-ds-release`).
+Trigger the `Version bump, changelog` workflow. It bumps the version in
+`package.json` + `package-lock.json`, generates a `CHANGELOG.md` entry from
+conventional commits since the last tag, commits to `main`, and pushes the
+tag. The tag push then triggers `release.yml` to build a draft GitHub release.
 
-1. **Sync to latest main.** The worktree is detached, so `git pull` won't work
-   — fetch and re-point HEAD instead:
-
-   ```bash
-   cd /tmp/cube-ds-release && git fetch origin && git checkout --detach origin/main
-   ```
-
-2. **Determine the version bump.** Review commits since the last tag:
-
-   ```
-   git log $(git describe --tags --abbrev=0)..HEAD --oneline
-   ```
-
-   - New features → `minor`
-   - Bug fixes only → `patch`
-   - Breaking changes → `major`
-
-   Ask the user to confirm the version if unsure.
-
-3. **Create the release branch and bump:**
-
-   ```bash
-   git checkout -b release/v<VERSION>
-   npm version <patch|minor|major> --no-git-tag-version
-   ```
-
-4. **Update `CHANGELOG.md`.** Prepend a new section after `# Changelog`:
-
-   ```markdown
-   ## <VERSION> (<YYYY-MM-DD>)
-
-   ### Features | Bug Fixes | Security | Breaking Changes
-
-   - **Short bold title**: Description (#PR)
-
-   **Full Changelog**: [v<PREV>...v<VERSION>](https://github.com/grafana/grafana-cube-datasource/compare/v<PREV>...v<VERSION>)
-   ```
-
-   Only list user-facing changes (features, fixes, security, deprecations).
-   Skip dependency bumps unless they fix a CVE worth calling out.
-
-5. **Commit, push, and open the PR:**
-
-   ```bash
-   git add package.json package-lock.json CHANGELOG.md
-   git commit -m "chore: release v<VERSION>"
-   git push -u origin HEAD
-   gh pr create --title "chore: release v<VERSION>" --body "..."
-   ```
-
-   PR body should include a summary table of what's included and a release
-   checklist (CI, merge, tag, CD).
-
-6. **Babysit the release PR** using the same polling loop from Phase 1.
-
-7. **Merge** when green:
-   `gh pr merge <PR> --repo grafana/grafana-cube-datasource --squash --delete-branch`
-
-## Phase 3 — Tag & push
-
-Still inside the worktree. Re-point the detached HEAD to the freshly merged
-`main` (don't use `git checkout main` — `main` is checked out in the user's
-primary worktree):
+**Determine the version bump.** Review commits since the last tag:
 
 ```bash
-cd /tmp/cube-ds-release
-git fetch origin && git checkout --detach origin/main
-git tag v<VERSION>
-git push origin v<VERSION>
+LAST_TAG=$(gh release list --repo grafana/grafana-cube-datasource --limit 1 --json tagName --jq '.[0].tagName')
+gh api "repos/grafana/grafana-cube-datasource/compare/${LAST_TAG}...main" \
+  --jq '.commits[] | "\(.sha[:8]) \(.commit.message | split("\n")[0])"'
 ```
 
-This triggers `.github/workflows/release.yml` which:
-- Builds and signs the plugin for all platforms
-- Creates a **draft** GitHub release with artifacts and SHA checksums
-- Generates provenance attestation
+- Any `feat:` → `minor`
+- Only `fix:` / `chore:` / `docs:` / `ci:` etc. → `patch`
+- Any `feat!:` or `BREAKING CHANGE:` → `major`
 
-Verify the release workflow completes:
+Ask the user to confirm the version if unsure.
 
+**Trigger the workflow:**
+
+```bash
+gh workflow run version-bump-changelog.yml \
+  --repo grafana/grafana-cube-datasource \
+  -f version=<patch|minor|major> -f generate-changelog=true
 ```
-gh run list --workflow=release.yml --limit 1 --repo grafana/grafana-cube-datasource
+
+Wait for it to complete:
+
+```bash
+gh run list --workflow=version-bump-changelog.yml --limit 1 \
+  --repo grafana/grafana-cube-datasource \
+  --json status,conclusion,displayTitle
 ```
 
-Then publish the draft release:
+A successful run pushes a `vX.Y.Z` tag, which triggers `release.yml` to build
+a **draft** GitHub release with signed plugin artefacts, SHA checksums and
+provenance attestation. Wait for that workflow too:
 
+```bash
+gh run list --workflow=release.yml --limit 1 \
+  --repo grafana/grafana-cube-datasource \
+  --json status,conclusion,displayTitle
 ```
+
+Publish the draft release:
+
+```bash
 gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --draft=false
 ```
 
-**Clean up the worktree** now that git operations are done:
-
-```bash
-git worktree remove /tmp/cube-ds-release
-```
-
-## Phase 4 — CD deployment
+## Phase 3 — CD deployment
 
 The CD workflow (`.github/workflows/publish.yaml`) publishes to the Grafana
 plugin catalog. It is triggered via `workflow_dispatch`. Each environment is
@@ -172,13 +114,15 @@ proceeding.
 
 Poll the run with:
 
-```
-gh run list --workflow=publish.yaml --limit 1 --repo grafana/grafana-cube-datasource --json status,conclusion,displayTitle
+```bash
+gh run list --workflow=publish.yaml --limit 1 \
+  --repo grafana/grafana-cube-datasource \
+  --json status,conclusion,displayTitle
 ```
 
 Wait for `"status": "completed"` and `"conclusion": "success"`.
 
-## Phase 5 — Internal post-publish steps
+## Phase 4 — Internal post-publish steps
 
 After the catalog publish completes, follow the internal post-publish runbook
 to bump the plugin on the relevant Grafana Cloud instances and restart them.

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,19 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 # Creates GitHub releases with downloadable artifacts when version tags are pushed.
 # This runs in addition to the CD workflow (publish.yaml) which publishes to the Grafana catalog.
 #
-# To create a release:
-#   1. Bump version: npm version patch|minor|major
-#   2. Push with tags: git push --follow-tags
+# To create a release: trigger the "Version bump, changelog" workflow
+# (.github/workflows/version-bump-changelog.yml) from the Actions tab. It bumps
+# the npm version, generates a CHANGELOG entry, commits to main and pushes the
+# tag — which is what triggers this workflow.
 #
 # The workflow will create a draft GitHub release with:
 #   - Signed plugin zip files for all platforms

--- a/.github/workflows/version-bump-changelog.yml
+++ b/.github/workflows/version-bump-changelog.yml
@@ -1,0 +1,33 @@
+name: Version bump, changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver type of new version (major / minor / patch)"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      generate-changelog:
+        description: "Generate changelog"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-x64-small
+
+    steps:
+      - name: Version bump
+        uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@plugins-version-bump-changelog/v1.1.0
+        with:
+          generate-changelog: ${{ inputs.generate-changelog }}
+          version: ${{ inputs.version }}

--- a/README.md
+++ b/README.md
@@ -290,12 +290,15 @@ A: For Grafana Cloud deployment, use the **"Plugins - CD"** workflow in the Acti
 
 ## Releasing
 
-This repository uses a **two-step release process**:
+This repository uses a **three-workflow release pipeline**:
 
-1. **GitHub Release** (via `release.yml`) — Created automatically when you push a version tag
-2. **Catalog Publishing** (via `publish.yaml`) — Manual workflow to publish to Grafana Cloud environments
+1. **`version-bump-changelog.yml`** — Manual workflow that bumps the npm version, generates a `CHANGELOG.md` entry from conventional commits since the last tag, commits to `main`, and pushes the new tag.
+2. **`release.yml`** — Triggered automatically by the tag push. Builds and signs the plugin for all platforms, creates a **draft** GitHub release with the artifacts, SHA checksums, and provenance attestation.
+3. **`publish.yaml`** ("Plugins - CD") — Manual workflow that publishes to the Grafana Cloud plugin catalog (dev / ops / prod-canary / prod).
 
-### Why Two Separate Workflows?
+The version bump and tag step happens entirely in CI — no local `git` or `npm` commands are required.
+
+### Why Separate `release.yml` from `publish.yaml`?
 
 We want GitHub releases with downloadable artifacts to be available **as soon as a version is tagged**, regardless of whether it's published to the Grafana catalog. This allows:
 
@@ -303,41 +306,29 @@ We want GitHub releases with downloadable artifacts to be available **as soon as
 - Transparency about what version exists, even if only deployed to dev/ops
 - A clear audit trail of all released versions
 
-The standard `plugin-ci-workflows` only creates GitHub releases when publishing to prod. Our custom `release.yml` fills this gap by creating releases on any tag push.
+The standard `plugin-ci-workflows` only creates GitHub releases when publishing to prod. Our `release.yml` fills this gap by creating releases on any tag push.
 
 ### Creating a Release
 
-Since `main` is protected, releases are a two-step process:
+PR titles must use conventional commit prefixes (`feat:`, `fix:`, `chore:`, …) — enforced by the `Conventional Commits` check on every PR. The prefix decides which `CHANGELOG.md` section the change is filed under, and the same convention drives the SemVer bump:
 
-**Step 1: Version bump PR**
+- Any `feat:` since the last tag → `minor`
+- Only `fix:` / `chore:` / `docs:` etc. → `patch`
+- `feat!:` or `BREAKING CHANGE:` in the body → `major`
 
-```bash
-# Create a release branch
-git checkout -b release/v1.2.3
+To cut a release:
 
-# Bump version (updates package.json and package-lock.json)
-npm version patch --no-git-tag-version  # or minor/major
+1. Go to **Actions** → **"Version bump, changelog"** → **"Run workflow"**.
+2. Pick the bump type (`patch` / `minor` / `major`) and run.
 
-# Commit the version bump
-git add package.json package-lock.json
-git commit -m "chore: release v1.2.3"
+The `grafana-plugins-platform-bot` will commit the version bump and `CHANGELOG.md` to `main` and push the new tag. The tag push triggers `release.yml`, which produces a draft GitHub release ready for review and publishing.
 
-# Push and create PR
-git push -u origin release/v1.2.3
-```
-
-Wait for CI to pass, then merge the PR.
-
-**Step 2: Tag the release**
+You can also trigger the workflow from the CLI:
 
 ```bash
-# After merging, pull main and create the tag
-git checkout main && git pull
-git tag v1.2.3
-git push origin v1.2.3
+gh workflow run version-bump-changelog.yml \
+  -f version=patch -f generate-changelog=true
 ```
-
-The tag push triggers the `release.yml` workflow, which creates a GitHub release with signed plugin artifacts. You can then publish to the catalog whenever you're ready.
 
 ## Publishing Workflow
 


### PR DESCRIPTION
## Summary

Automates the manual release ceremony and enforces conventional commits so the auto-generated CHANGELOG is useful.

### What's added

- **`.github/workflows/version-bump-changelog.yml`** — manual `workflow_dispatch` action that bumps the npm version (patch / minor / major), regenerates `CHANGELOG.md` from commits since the last tag, commits to `main` and pushes the new tag. The tag push triggers the existing `release.yml` to build artefacts and draft a GitHub release. Pinned to `@plugins-version-bump-changelog/v1.1.0` per the official example.
- **`.github/workflows/conventional-commits.yml`** — runs on every PR and fails if the title isn't a conventional commit prefix. Same setup as `grafana/logs-drilldown`.

### What changes in the docs

- **`.cursor/skills/release/SKILL.md`** — collapses the previous Phase 2 (manual version bump + CHANGELOG editing + release PR) and Phase 3 (worktree dance, tag, push tag) into a single short "Cut the release" phase. The "Run locally" notice and worktree setup section are gone — there are no local `git` or `npm` commands in the new flow.
- **`README.md`** — "Releasing" / "Creating a Release" rewritten around the new three-workflow pipeline (version-bump → release → publish). Documents how the conventional-commit prefix decides both the SemVer bump and the CHANGELOG section.
- **`.github/workflows/release.yml`** — header comment updated to point at the new trigger source instead of the obsolete `npm version` + `git push --follow-tags` instructions.

## Net effect

Cutting a release goes from "create a release branch, edit CHANGELOG by hand, open a PR, wait for review, merge, pull, tag, push tag" to "click Run workflow → pick patch/minor/major → wait → publish the draft release".

## Test plan

- [x] CI passes (incl. the new `Conventional Commits` check on this PR's title)
- [ ] Diff reviewed for accuracy of the new docs against the actual workflow behaviour
- [ ] Exercise the new workflow on the next real release and confirm the bot can push to `main` (it works on `logs-drilldown` with the same ruleset, so should work here)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CI workflows that can commit to `main` and push release tags, and enforces PR-title conventions that may block merges if misconfigured.
> 
> **Overview**
> **Automates the release cut in CI** by adding a manual `version-bump-changelog.yml` workflow that bumps npm version, generates `CHANGELOG.md`, commits to `main`, and pushes a `v*` tag (which then triggers the existing `release.yml` to build a draft GitHub release).
> 
> **Enforces conventional commits on PR titles** via a new `conventional-commits.yml` check using `action-semantic-pull-request`, and updates `release.yml`/docs (`README.md` and `.cursor/skills/release/SKILL.md`) to remove the old local/worktree-based release steps in favor of the new workflow-driven process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872baf22d711e78d9df09efcc1b300846ac12d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->