### PR TITLE
chore: drop deprecated tsconfig `baseUrl`

### DIFF
--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -9,7 +9,6 @@
     "alwaysStrict": true,
     "declaration": false,
     "rootDir": "../src",
-    "baseUrl": "../src",
     "typeRoots": ["../node_modules/@types"],
     "resolveJsonModule": true
   },

--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
-import { setup } from 'testUtils';
+import { setup } from '../testUtils';
 import { ConfigEditor } from './ConfigEditor';
 import { CubeDataSourceOptions, CubeSecureJsonData } from '../types';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, useMemo } from 'react';
 import { InlineField, Input, SecretInput, RadioButtonGroup, Alert, Combobox, ComboboxOption } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { CubeDataSourceOptions, CubeSecureJsonData } from '../types';
-import { useSqlDatasourcesQuery } from 'queries';
+import { useSqlDatasourcesQuery } from '../queries';
 
 // Constants
 const FIELD_WIDTHS = {

--- a/src/components/DataModelConfigPage.test.tsx
+++ b/src/components/DataModelConfigPage.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@grafana/ui', () => ({
 
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { setup } from 'testUtils';
+import { setup } from '../testUtils';
 import { DataModelConfigPage, extractDatasourceUid } from './DataModelConfigPage';
 import { getBackendSrv } from '@grafana/runtime';
 

--- a/src/components/DatabaseTree.test.tsx
+++ b/src/components/DatabaseTree.test.tsx
@@ -8,7 +8,7 @@ jest.mock('@grafana/runtime', () => ({
 
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { setup } from 'testUtils';
+import { setup } from '../testUtils';
 import { DatabaseTree, encodeTableKey } from './DatabaseTree';
 import { getBackendSrv } from '@grafana/runtime';
 

--- a/src/components/FileList.test.tsx
+++ b/src/components/FileList.test.tsx
@@ -7,7 +7,7 @@ jest.mock('@grafana/runtime', () => ({
 
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { setup } from 'testUtils';
+import { setup } from '../testUtils';
 import { FileList } from './FileList';
 import { ModelFile } from '../types';
 

--- a/src/components/FilterField/FilterField.test.tsx
+++ b/src/components/FilterField/FilterField.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { createMockDataSource, setup } from 'testUtils';
+import { createMockDataSource, setup } from '../../testUtils';
 import { FilterField } from './FilterField';
-import { Operator } from 'types';
+import { Operator } from '../../types';
 
 describe('FilterField', () => {
   const mockOnChange = jest.fn();

--- a/src/components/OrderBy/OrderBy.test.tsx
+++ b/src/components/OrderBy/OrderBy.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { setup } from 'testUtils';
+import { setup } from '../../testUtils';
 import { OrderBy } from './OrderBy';
-import { DEFAULT_ORDER } from 'types';
+import { DEFAULT_ORDER } from '../../types';
 
 describe('OrderBy', () => {
   const mockOnAdd = jest.fn();

--- a/src/components/OrderBy/OrderBy.tsx
+++ b/src/components/OrderBy/OrderBy.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Select, useStyles2 } from '@grafana/ui';
-import { DEFAULT_ORDER, Order } from 'types';
+import { DEFAULT_ORDER, Order } from '../../types';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';

--- a/src/components/OrderBy/OrderByItem.tsx
+++ b/src/components/OrderBy/OrderByItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IconButton, useStyles2, Text } from '@grafana/ui';
-import { Order } from 'types';
+import { Order } from '../../types';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Draggable } from '@hello-pangea/dnd';

--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -4,7 +4,7 @@ import * as GrafanaUI from '@grafana/ui';
 import { QueryEditor } from './QueryEditor';
 import { CubeQuery, Operator } from '../types';
 import { getTemplateSrv } from '@grafana/runtime';
-import { createMockDataSource, setup } from 'testUtils';
+import { createMockDataSource, setup } from '../testUtils';
 
 // Mock the SQLPreview component
 jest.mock('./SQLPreview', () => ({

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -6,7 +6,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from '../datasource';
 import { CubeDataSourceOptions, CubeQuery, CubeFilter, isCubeFilter } from '../types';
 import { SQLPreview } from './SQLPreview';
-import { useMetadataQuery, useCompiledSqlQuery, MetadataOption } from 'queries';
+import { useMetadataQuery, useCompiledSqlQuery, MetadataOption } from '../queries';
 import { OrderBy } from './OrderBy/OrderBy';
 import { FilterField } from './FilterField/FilterField';
 import { useQueryEditorHandlers } from '../hooks/useQueryEditorHandlers';

--- a/src/components/SQLPreview.test.tsx
+++ b/src/components/SQLPreview.test.tsx
@@ -14,9 +14,9 @@ jest.mock('queries', () => ({
 
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { setup } from 'testUtils';
+import { setup } from '../testUtils';
 import { SQLPreview } from './SQLPreview';
-import { useDatasourceQuery } from 'queries';
+import { useDatasourceQuery } from '../queries';
 
 const mockUseDatasourceQuery = useDatasourceQuery as jest.Mock;
 

--- a/src/components/SQLPreview.test.tsx
+++ b/src/components/SQLPreview.test.tsx
@@ -8,7 +8,7 @@ jest.mock('prismjs', () => ({
 jest.mock('prismjs/components/prism-sql', () => ({}));
 
 // Mock the useDatasourceQuery hook
-jest.mock('queries', () => ({
+jest.mock('../queries', () => ({
   useDatasourceQuery: jest.fn(),
 }));
 

--- a/src/components/SQLPreview.tsx
+++ b/src/components/SQLPreview.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { LinkButton, useTheme2 } from '@grafana/ui';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-sql';
-import { useDatasourceQuery } from 'queries';
+import { useDatasourceQuery } from '../queries';
 
 interface SQLPreviewProps {
   sql: string;

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,7 @@ import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
 import { DataModelConfigPage } from './components/DataModelConfigPage';
 import { CubeQuery, CubeDataSourceOptions } from './types';
-import { withQueryClient } from 'queryClient';
+import { withQueryClient } from './queryClient';
 
 export const plugin = new DataSourcePlugin<DataSource, CubeQuery, CubeDataSourceOptions>(DataSource)
   .setConfigEditor(withQueryClient(ConfigEditor))

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient, UseQueryResult } from '@tanstack/react-query';
 import { SelectableValue } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-import { DataSource } from 'datasource';
+import { DataSource } from './datasource';
 import { fetchSqlDatasources } from './services/datasourceApi';
 import { DbSchemaResponse, GenerateSchemaRequest, ModelFilesResponse } from './types';
 

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -3,8 +3,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { CubeDataSourceOptions } from 'types';
-import { DataSource } from 'datasource';
+import { CubeDataSourceOptions } from './types';
+import { DataSource } from './datasource';
 
 export function setup(ui: React.ReactElement) {
   const client = new QueryClient({


### PR DESCRIPTION
## Summary

- Removes `baseUrl: "../src"` from the scaffolded `.config/tsconfig.json` (deprecated in TypeScript 6, removed in 7).
- Rewrites the source/test files that relied on it to use relative imports — matching the convention already used by other files in the same directories.
- Updates one corresponding `jest.mock('queries', ...)` call to use the same relative specifier so the mock is unambiguous (caught by Bugbot — was previously working only because of `modulePaths: ['<rootDir>/src']` in the Jest config).
- Combined with `@grafana/tsconfig@2.1.0` (already on `main`, which switched `moduleResolution` from `node` → `bundler` and dropped `downlevelIteration`), this means `tsc --noEmit` now passes cleanly under **both TypeScript 5.9 and TypeScript 6.0** with no `ignoreDeprecations` escape hatch.

## Knock-on effect for #239

PR #239 (`chore(deps): update dependency typescript to v6`) currently carries a temporary `"ignoreDeprecations": "6.0"` line I added so the typescript bump alone could pass CI while this larger fix was prepared. Once this PR merges, that one-line band-aid in #239 can be dropped and the renovate PR reverts to the clean one-line typescript bump it was meant to be.

## Why touch a "do not edit directly" file?

`.config/tsconfig.json` is scaffolded by `@grafana/create-plugin` and the file header asks not to edit it directly. The proper workflow is `npx @grafana/create-plugin@latest update` — but `create-plugin@7.3.0` still ships `baseUrl: "../src"` in its template (`No migrations to run`), so the update tool can't help us here. `baseUrl` also can't be unset from the root `tsconfig.json` because TypeScript has no "remove an inherited option" mechanism. Editing the scaffolded file is the only path that leaves no compromise.

### Conflict risk with future scaffold updates

Low, for a structural reason. `create-plugin update` is **not** a wholesale "regenerate scaffold" operation — it's a sequence of targeted, idempotent codemods (see `migrations.ts` listing the 7 migrations to date — `001-update-grafana-compose-extend`, `006-webpack-nested-fix`, etc.). Each migration parses the AST, looks for an exact pattern, and only writes if the pattern matched. A hypothetical future `008-remove-tsconfig-baseUrl` migration would find nothing on our already-fixed file and silently no-op.

### Upstream issue

I've filed [grafana/plugin-tools#2613](https://github.com/grafana/plugin-tools/issues/2613) requesting that the scaffold itself drop `baseUrl`. Their TS6 support PR ([#2595](https://github.com/grafana/plugin-tools/pull/2595), merged 2026-04-30) only fixed the two deprecations that lived in `@grafana/tsconfig` and consciously left this one untouched. Once they fix it, our edit becomes a no-op rather than a divergence.

## Test plan

- [x] `npm run typecheck` — passes (under installed TypeScript 5.9.3)
- [x] `npx -p typescript@6.0.3 -- tsc --noEmit` — passes (verifies the TS6 path, no `ignoreDeprecations` needed)
- [x] `npm run lint` — passes (only pre-existing deprecated-Select warnings)
- [x] `npm run test:ci` — 250/250 passing
- [x] `npm run build` — succeeds
- [x] CI green except a flaky `Playwright E2E / dev-preview-react19` variant — confirmed flaky on `main` itself in adjacent runs (Grafana server start timing out before tests run); retrying.