### PR TITLE
feat!: remove legacy order object format and cubeApiUrl jsonData field

### DIFF
--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -8,7 +8,7 @@ import (
 )
 
 type PluginSettings struct {
-	CubeApiUrl              string                `json:"cubeApiUrl"`
+	CubeApiUrl              string                `json:"-"`
 	DeploymentType          string                `json:"deploymentType"` // "cloud", "self-hosted", or "self-hosted-dev"
 	ExploreSqlDatasourceUid string                `json:"exploreSqlDatasourceUid"`
 	Secrets                 *SecretPluginSettings `json:"-"`
@@ -26,13 +26,7 @@ func LoadPluginSettings(source backend.DataSourceInstanceSettings) (*PluginSetti
 		return nil, fmt.Errorf("could not unmarshal PluginSettings json: %w", err)
 	}
 
-	// Prefer the standard top-level datasource URL over jsonData.cubeApiUrl.
-	// This makes provisioning and Terraform idiomatic (most Grafana datasources use "url"),
-	// while remaining backward-compatible with existing instances that use jsonData.cubeApiUrl.
-	if source.URL != "" {
-		settings.CubeApiUrl = source.URL
-	}
-
+	settings.CubeApiUrl = source.URL
 	settings.Secrets = loadSecretPluginSettings(source.DecryptedSecureJSONData)
 
 	return &settings, nil

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -8,7 +8,7 @@ import (
 )
 
 type PluginSettings struct {
-	CubeApiUrl              string                `json:"-"`
+	URL              string                `json:"-"`
 	DeploymentType          string                `json:"deploymentType"` // "cloud", "self-hosted", or "self-hosted-dev"
 	ExploreSqlDatasourceUid string                `json:"exploreSqlDatasourceUid"`
 	Secrets                 *SecretPluginSettings `json:"-"`
@@ -26,7 +26,7 @@ func LoadPluginSettings(source backend.DataSourceInstanceSettings) (*PluginSetti
 		return nil, fmt.Errorf("could not unmarshal PluginSettings json: %w", err)
 	}
 
-	settings.CubeApiUrl = source.URL
+	settings.URL = source.URL
 	settings.Secrets = loadSecretPluginSettings(source.DecryptedSecureJSONData)
 
 	return &settings, nil

--- a/pkg/models/settings_test.go
+++ b/pkg/models/settings_test.go
@@ -20,7 +20,7 @@ func TestLoadPluginSettings(t *testing.T) {
 			deploymentType: "self-hosted-dev",
 		},
 		{
-			name:           "empty URL results in empty CubeApiUrl",
+			name:           "empty URL results in empty URL",
 			sourceURL:      "",
 			expectedURL:    "",
 			deploymentType: "self-hosted-dev",
@@ -41,8 +41,8 @@ func TestLoadPluginSettings(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			if settings.CubeApiUrl != tt.expectedURL {
-				t.Errorf("Expected CubeApiUrl %q, got %q", tt.expectedURL, settings.CubeApiUrl)
+			if settings.URL != tt.expectedURL {
+				t.Errorf("Expected URL %q, got %q", tt.expectedURL, settings.URL)
 			}
 		})
 	}

--- a/pkg/models/settings_test.go
+++ b/pkg/models/settings_test.go
@@ -10,35 +10,18 @@ func TestLoadPluginSettings(t *testing.T) {
 	tests := []struct {
 		name           string
 		sourceURL      string
-		jsonDataURL    string
 		expectedURL    string
 		deploymentType string
 	}{
 		{
-			name:           "prefers top-level URL over jsonData.cubeApiUrl",
+			name:           "uses top-level URL",
 			sourceURL:      "http://standard-url:4000",
-			jsonDataURL:    "http://legacy-url:4000",
 			expectedURL:    "http://standard-url:4000",
 			deploymentType: "self-hosted-dev",
 		},
 		{
-			name:           "falls back to jsonData.cubeApiUrl when top-level URL is empty",
+			name:           "empty URL results in empty CubeApiUrl",
 			sourceURL:      "",
-			jsonDataURL:    "http://legacy-url:4000",
-			expectedURL:    "http://legacy-url:4000",
-			deploymentType: "self-hosted-dev",
-		},
-		{
-			name:           "uses top-level URL when jsonData.cubeApiUrl is not set",
-			sourceURL:      "http://standard-url:4000",
-			jsonDataURL:    "",
-			expectedURL:    "http://standard-url:4000",
-			deploymentType: "self-hosted-dev",
-		},
-		{
-			name:           "both empty results in empty URL",
-			sourceURL:      "",
-			jsonDataURL:    "",
 			expectedURL:    "",
 			deploymentType: "self-hosted-dev",
 		},
@@ -46,11 +29,7 @@ func TestLoadPluginSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jsonData := `{"deploymentType": "` + tt.deploymentType + `"`
-			if tt.jsonDataURL != "" {
-				jsonData += `, "cubeApiUrl": "` + tt.jsonDataURL + `"`
-			}
-			jsonData += `}`
+			jsonData := `{"deploymentType": "` + tt.deploymentType + `"}`
 
 			source := backend.DataSourceInstanceSettings{
 				URL:      tt.sourceURL,

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -197,7 +197,7 @@ func (d *Datasource) buildAPIURL(pluginContext backend.PluginContext, endpoint s
 	}
 
 	// Get base URL with test override support
-	baseURL := config.CubeApiUrl
+	baseURL := config.URL
 	if d.BaseURL != "" {
 		// Override for testing
 		baseURL = d.BaseURL

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -147,8 +147,8 @@ func TestBuildAPIURL(t *testing.T) {
 				t.Fatalf("Expected config to be returned, got nil")
 			}
 
-			if apiReq.Config.CubeApiUrl != tt.sourceURL {
-				t.Fatalf("Expected config.CubeApiUrl '%s', got '%s'", tt.sourceURL, apiReq.Config.CubeApiUrl)
+			if apiReq.Config.URL != tt.sourceURL {
+				t.Fatalf("Expected config.URL '%s', got '%s'", tt.sourceURL, apiReq.Config.URL)
 			}
 		})
 	}

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -15,15 +15,13 @@ import (
 func TestBuildAPIURL(t *testing.T) {
 	tests := []struct {
 		name            string
-		sourceURL       string // top-level datasource URL field (preferred)
-		legacyJsonUrl   string // legacy jsonData.cubeApiUrl (backward-compat tests only)
+		sourceURL       string
 		baseURLOverride string
 		endpoint        string
 		expectError     bool
 		expectedURL     string
 		errorContains   string
 	}{
-		// Valid URL cases (using standard top-level URL field)
 		{
 			name:        "valid HTTP URL",
 			sourceURL:   "http://localhost:4000",
@@ -66,22 +64,6 @@ func TestBuildAPIURL(t *testing.T) {
 			endpoint:        "sql",
 			expectError:     false,
 			expectedURL:     "http://test-server:3000/cubejs-api/v1/sql",
-		},
-		// Backward-compatibility: top-level URL takes precedence over legacy jsonData.cubeApiUrl
-		{
-			name:          "top-level URL preferred over legacy jsonData.cubeApiUrl",
-			legacyJsonUrl: "http://legacy:4000",
-			sourceURL:     "http://standard:4000",
-			endpoint:      "load",
-			expectError:   false,
-			expectedURL:   "http://standard:4000/cubejs-api/v1/load",
-		},
-		{
-			name:        "top-level URL used when legacy jsonData.cubeApiUrl is empty",
-			sourceURL:   "http://standard:4000",
-			endpoint:    "meta",
-			expectError: false,
-			expectedURL: "http://standard:4000/cubejs-api/v1/meta",
 		},
 		// Invalid URL cases
 		{
@@ -137,7 +119,7 @@ func TestBuildAPIURL(t *testing.T) {
 			pluginContext := backend.PluginContext{
 				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
 					URL:      tt.sourceURL,
-					JSONData: []byte(`{"cubeApiUrl": "` + tt.legacyJsonUrl + `"}`),
+					JSONData: []byte(`{}`),
 				},
 			}
 
@@ -165,14 +147,8 @@ func TestBuildAPIURL(t *testing.T) {
 				t.Fatalf("Expected config to be returned, got nil")
 			}
 
-			// Verify config contains the resolved URL.
-			// Top-level sourceURL takes precedence over legacy jsonData.cubeApiUrl.
-			expectedConfigURL := tt.legacyJsonUrl
-			if tt.sourceURL != "" {
-				expectedConfigURL = tt.sourceURL
-			}
-			if apiReq.Config.CubeApiUrl != expectedConfigURL {
-				t.Fatalf("Expected config.CubeApiUrl '%s', got '%s'", expectedConfigURL, apiReq.Config.CubeApiUrl)
+			if apiReq.Config.CubeApiUrl != tt.sourceURL {
+				t.Fatalf("Expected config.CubeApiUrl '%s', got '%s'", tt.sourceURL, apiReq.Config.CubeApiUrl)
 			}
 		})
 	}

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -493,7 +493,7 @@ func (d *Datasource) fetchCubeModelFiles(ctx context.Context, pluginContext back
 	}
 
 	// Get base URL with test override support
-	baseURL := apiReq.Config.CubeApiUrl
+	baseURL := apiReq.Config.URL
 	if d.BaseURL != "" {
 		// Override for testing
 		baseURL = d.BaseURL
@@ -597,7 +597,7 @@ func (d *Datasource) fetchCubeDbSchema(ctx context.Context, pluginContext backen
 	}
 
 	// Get base URL with test override support
-	baseURL := apiReq.Config.CubeApiUrl
+	baseURL := apiReq.Config.URL
 	if d.BaseURL != "" {
 		// Override for testing
 		baseURL = d.BaseURL
@@ -701,7 +701,7 @@ func (d *Datasource) fetchCubeGenerateSchema(ctx context.Context, pluginContext 
 	}
 
 	// Get base URL with test override support
-	baseURL := apiReq.Config.CubeApiUrl
+	baseURL := apiReq.Config.URL
 	if d.BaseURL != "" {
 		// Override for testing
 		baseURL = d.BaseURL

--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -65,41 +65,7 @@ describe('ConfigEditor', () => {
       expect(urlInput.value).toBe('https://standard-url.com');
     });
 
-    it('should fall back to jsonData.cubeApiUrl for backward compatibility', () => {
-      const props = createMockEditorProps({
-        options: {
-          ...createMockEditorProps().options,
-          url: '',
-          jsonData: {
-            cubeApiUrl: 'https://legacy-url.com',
-            deploymentType: 'self-hosted-dev',
-          },
-        },
-      });
-      setup(<ConfigEditor {...props} />);
-
-      const urlInput = screen.getByLabelText('Cube API URL') as HTMLInputElement;
-      expect(urlInput.value).toBe('https://legacy-url.com');
-    });
-
-    it('should prefer top-level url over jsonData.cubeApiUrl', () => {
-      const props = createMockEditorProps({
-        options: {
-          ...createMockEditorProps().options,
-          url: 'https://standard-url.com',
-          jsonData: {
-            cubeApiUrl: 'https://legacy-url.com',
-            deploymentType: 'self-hosted-dev',
-          },
-        },
-      });
-      setup(<ConfigEditor {...props} />);
-
-      const urlInput = screen.getByLabelText('Cube API URL') as HTMLInputElement;
-      expect(urlInput.value).toBe('https://standard-url.com');
-    });
-
-    it('should write to both standard url and jsonData.cubeApiUrl when URL is modified', () => {
+    it('should write url when URL is modified', () => {
       const props = createMockEditorProps();
       setup(<ConfigEditor {...props} />);
 
@@ -109,10 +75,6 @@ describe('ConfigEditor', () => {
       expect(props.onOptionsChange).toHaveBeenCalledWith({
         ...props.options,
         url: 'http://new-url:4000',
-        jsonData: {
-          ...props.options.jsonData,
-          cubeApiUrl: 'http://new-url:4000',
-        },
       });
     });
   });

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -19,8 +19,7 @@ export function ConfigEditor({ onOptionsChange, options }: ConfigEditorProps) {
   // No default - user must explicitly select deployment type
   const deploymentType = jsonData.deploymentType;
 
-  // Read from standard top-level url, falling back to legacy jsonData.cubeApiUrl
-  const cubeApiUrl = options.url || jsonData.cubeApiUrl || '';
+  const cubeApiUrl = options.url || '';
 
   // Memoized datasource options for Combobox
   const sqlDatasourceOptions = useMemo(
@@ -36,7 +35,6 @@ export function ConfigEditor({ onOptionsChange, options }: ConfigEditorProps) {
     onOptionsChange({
       ...options,
       url: value,
-      jsonData: { ...jsonData, cubeApiUrl: value },
     });
 
   const updateJsonData = (field: keyof CubeDataSourceOptions, value: string | undefined) =>

--- a/src/components/OrderBy/OrderBy.test.tsx
+++ b/src/components/OrderBy/OrderBy.test.tsx
@@ -107,24 +107,4 @@ describe('OrderBy', () => {
     expect(mockOnToggleDirection).toHaveBeenCalledWith('orders.status');
   });
 
-  it('should handle legacy object format for backward compatibility', async () => {
-    const { user } = setup(
-      <OrderBy
-        availableOptions={mockOptions}
-        onAdd={mockOnAdd}
-        onRemove={mockOnRemove}
-        onToggleDirection={mockOnToggleDirection}
-        onReorder={mockOnReorder}
-        order={{ 'orders.status': 'desc' }}
-      />
-    );
-
-    // Should render the order field from legacy format
-    expect(screen.getByText('Status')).toBeInTheDocument();
-
-    // Should still work with callbacks
-    const removeButton = screen.getByRole('button', { name: 'Remove field from order by' });
-    await user.click(removeButton);
-    expect(mockOnRemove).toHaveBeenCalledWith('orders.status');
-  });
 });

--- a/src/components/OrderBy/OrderBy.tsx
+++ b/src/components/OrderBy/OrderBy.tsx
@@ -5,7 +5,8 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
 import { OrderByItem } from './OrderByItem';
-import { normalizeOrder, OrderInput } from '../../utils/normalizeOrder';
+import type { TQueryOrderArray } from '@cubejs-client/core';
+import { normalizeOrder } from '../../utils/normalizeOrder';
 
 interface OrderByProps {
   availableOptions: Array<{ label: string; value: string }>;
@@ -13,7 +14,7 @@ interface OrderByProps {
   onRemove: (field: string) => void;
   onToggleDirection: (field: string) => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
-  order?: OrderInput;
+  order?: TQueryOrderArray;
 }
 
 /**

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -530,23 +530,6 @@ describe('DataSource', () => {
       });
     });
 
-    describe('order normalization', () => {
-      it('should normalize legacy object order format to array format', () => {
-        const datasource = createDataSource();
-        const query = {
-          refId: 'A',
-          measures: ['orders.count'],
-          order: { 'orders.count': 'desc', 'orders.status': 'asc' } as CubeQuery['order'],
-        };
-
-        const result = datasource.applyTemplateVariables(query, {});
-
-        expect(result.order).toEqual([
-          ['orders.count', 'desc'],
-          ['orders.status', 'asc'],
-        ]);
-      });
-    });
   });
 
   describe('filterQuery', () => {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -22,7 +22,6 @@ const createDataSource = (options: Partial<CubeDataSourceOptions> = {}) => {
     name: 'Test Cube',
     meta: {} as any,
     jsonData: {
-      cubeApiUrl: 'http://localhost:4000',
       ...options,
     },
     readOnly: false,

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,6 +1,6 @@
 import { DataSource } from './datasource';
 import { DataSourceInstanceSettings } from '@grafana/data';
-import { CubeDataSourceOptions, CubeFilter, CubeQuery, Operator } from './types';
+import { CubeDataSourceOptions, CubeFilter, Operator } from './types';
 import { getTemplateSrv } from '@grafana/runtime';
 
 // Mock @grafana/runtime

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -34,7 +34,7 @@ export const createMockDataSource = (mockMetadata: any = null, mockSQLResponse: 
     type: 'cube-datasource',
     name: 'Test Cube',
     meta: {} as any,
-    jsonData: { cubeApiUrl: 'http://localhost:4000' },
+    jsonData: {},
     readOnly: false,
     access: 'proxy',
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { TimeDimension, TQueryOrderArray, TQueryOrderObject } from '@cubejs-client/core';
+import type { TimeDimension, TQueryOrderArray } from '@cubejs-client/core';
 import { DataSourceJsonData } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 
@@ -111,11 +111,7 @@ export interface CubeQuery extends DataQuery {
    * query editor to show the read-only JSON viewer.
    */
   filters?: CubeFilterItem[];
-  /**
-   * Order can be array format (new) or object format (legacy saved queries).
-   * Uses Cube's official order types for API compatibility.
-   */
-  order?: TQueryOrderArray | TQueryOrderObject;
+  order?: TQueryOrderArray;
 }
 
 export const DEFAULT_QUERY: Partial<CubeQuery> = {};
@@ -131,14 +127,9 @@ export interface DataSourceResponse {
 
 /**
  * These are options configured for each DataSource instance.
- *
  * The Cube API URL is stored in the standard top-level datasource `url` field.
- * The backend prefers `url` when set, falling back to `cubeApiUrl` for backward
- * compatibility with existing instances.
  */
 export interface CubeDataSourceOptions extends DataSourceJsonData {
-  /** @deprecated Use the standard datasource `url` field instead. Kept for backward compatibility. */
-  cubeApiUrl?: string;
   deploymentType?: 'cloud' | 'self-hosted' | 'self-hosted-dev';
   /** UID of the SQL datasource to use when clicking "Edit SQL in Explore" */
   exploreSqlDatasourceUid?: string;

--- a/src/utils/buildCubeQuery.test.ts
+++ b/src/utils/buildCubeQuery.test.ts
@@ -104,22 +104,6 @@ describe('buildCubeQueryJson', () => {
     ]);
   });
 
-  it('normalizes legacy object order format to array format', () => {
-    const datasource = createDatasourceStub();
-    const query: CubeQuery = {
-      refId: 'A',
-      measures: ['orders.count'],
-      order: { 'orders.count': 'desc', 'orders.status': 'asc' },
-    };
-
-    const result = JSON.parse(buildCubeQueryJson(query, datasource));
-
-    expect(result.order).toEqual([
-      ['orders.count', 'desc'],
-      ['orders.status', 'asc'],
-    ]);
-  });
-
   it('omits injected dashboard time dimension when $__from/$__to are invalid', () => {
     mockGetTemplateSrv.mockReturnValue({
       replace: (value: string) => {

--- a/src/utils/normalizeOrder.test.ts
+++ b/src/utils/normalizeOrder.test.ts
@@ -1,5 +1,5 @@
 import type { TQueryOrderArray } from '@cubejs-client/core';
-import { normalizeOrder, OrderArray, OrderRecord } from './normalizeOrder';
+import { normalizeOrder, OrderArray } from './normalizeOrder';
 
 describe('normalizeOrder', () => {
   it('should return undefined for undefined input', () => {
@@ -14,27 +14,12 @@ describe('normalizeOrder', () => {
     expect(normalizeOrder(arrayOrder)).toEqual(arrayOrder);
   });
 
-  it('should convert object format to array format', () => {
-    const objectOrder: OrderRecord = { 'orders.count': 'desc', 'orders.status': 'asc' };
-    const result = normalizeOrder(objectOrder);
-    expect(result).toEqual([
-      ['orders.count', 'desc'],
-      ['orders.status', 'asc'],
-    ]);
-  });
-
-  it('should return undefined for empty object', () => {
-    const result = normalizeOrder({});
-    expect(result).toBeUndefined();
-  });
-
   it('should return undefined for empty array', () => {
     const result = normalizeOrder([]);
     expect(result).toBeUndefined();
   });
 
   it('should filter out entries with none direction', () => {
-    // Using TQueryOrderArray to simulate Cube's type that includes 'none'
     const orderWithNone: TQueryOrderArray = [
       ['orders.count', 'desc'],
       ['orders.status', 'none'],

--- a/src/utils/normalizeOrder.ts
+++ b/src/utils/normalizeOrder.ts
@@ -1,4 +1,4 @@
-import type { TQueryOrderArray, TQueryOrderObject } from '@cubejs-client/core';
+import type { TQueryOrderArray } from '@cubejs-client/core';
 import { Order } from '../types';
 
 /**
@@ -6,22 +6,6 @@ import { Order } from '../types';
  * This is a subset of Cube's TQueryOrderArray that excludes 'none'.
  */
 export type OrderArray = Array<[string, Order]>;
-
-/**
- * Legacy object format from old saved queries: { "field": "asc" | "desc" }
- *
- * Deprecated because JavaScript object key order isn't guaranteed, but we need
- * deterministic ordering for the list of order-by entries. Use array format instead.
- */
-export type OrderRecord = Record<string, Order>;
-
-/**
- * Input type for normalizeOrder - accepts Cube's official types (which may include 'none').
- *
- * Our internal types (OrderArray, OrderRecord) are subtypes of Cube's types
- * (TQueryOrderArray, TQueryOrderObject), so TypeScript accepts them automatically.
- */
-export type OrderInput = TQueryOrderArray | TQueryOrderObject | undefined;
 
 /**
  * Type guard to check if a direction is a valid Order ('asc' | 'desc').
@@ -33,32 +17,14 @@ function isValidOrder(direction: string): direction is Order {
 
 /**
  * Normalizes order input to our internal OrderArray format.
- *
- * Handles two concerns:
- * 1. Format conversion: legacy object format → array format
- * 2. Direction filtering: removes 'none' entries (meaningless for sorting)
- *
- * Legacy format: { "orders.count": "desc" }
- * Current format: [["orders.count", "desc"]]
- *
+ * Filters out 'none' entries (valid in Cube but meaningless for sorting).
  * Returns OrderArray or undefined if no valid entries remain.
  */
-export function normalizeOrder(order: OrderInput): OrderArray | undefined {
-  if (!order) {
+export function normalizeOrder(order: TQueryOrderArray | undefined): OrderArray | undefined {
+  if (!order || order.length === 0) {
     return undefined;
   }
 
-  let entries: Array<[string, string]>;
-
-  if (Array.isArray(order)) {
-    entries = order;
-  } else {
-    // Convert object to array of tuples
-    entries = Object.entries(order);
-  }
-
-  // Filter out 'none' entries - they have no effect on sorting
-  const validEntries = entries.filter(([, direction]) => isValidOrder(direction)) as OrderArray;
-
+  const validEntries = order.filter(([, direction]) => isValidOrder(direction)) as OrderArray;
   return validEntries.length > 0 ? validEntries : undefined;
 }


### PR DESCRIPTION
Remove backward-compatibility fallbacks that are no longer needed on v0.
- query `order` field is now array-only; object format is rejected by TypeScript
- datasource URL is read exclusively from the standard top-level `url` field;
  `cubeApiUrl` in jsonData is no longer written or read

https://claude.ai/code/session_014BhfmdhiXT2jzXucAyJ3pN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it removes backward-compatibility paths: existing provisioned datasources relying on `jsonData.cubeApiUrl` or panels saved with object-form `order` may break or fail to compile after upgrade.
> 
> **Overview**
> Removes legacy configuration and query compatibility shims across backend and frontend.
> 
> Datasource base URL is now read **only** from Grafana’s standard top-level `url` field (backend `PluginSettings.URL`), and the config UI stops reading/writing `jsonData.cubeApiUrl`. Query `order` is now typed and handled as `TQueryOrderArray` only; the legacy object order format support and related normalization/tests are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e3222a14b7a07a178cbb140402d636f3a244b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->