### PR TITLE
ci: fix release-please workflow permissions and config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "packages": {


### PR DESCRIPTION
## Summary

Fixes issues identified by Bugbot on #319:

- **`id-token: write`** — the release-please composite action uses `get-vault-secrets` which needs OIDC. Without this permission the workflow fails.
- **`include-component-in-tag: false`** — ensures tags are `v1.2.3` not `grafana-cube-datasource-v1.2.3`.

Note: Bugbot also suggested `skip-github-release: true`, but that option is [broken upstream](https://github.com/googleapis/release-please/issues/1561) — it prevents both tag and release creation and breaks release-please's state tracking. It's not needed here because `build-plugin` uses `softprops/action-gh-release` which safely updates the release that release-please already created.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, the release-please workflow runs successfully on the next push to `main`
- [ ] Release PR is opened/updated with correct `v*` tag format