### PR TITLE
ci: auto-publish release with CHANGELOG.md as body

### DIFF
--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -84,10 +84,39 @@ gh run list --workflow=release.yml --limit 1 \
   --json status,conclusion,displayTitle
 ```
 
-Publish the draft release:
+**Edit the draft's release notes** before publishing — the
+`grafana/plugin-actions/build-plugin` action populates the body with submission
+boilerplate that's irrelevant to consumers. Replace it with the matching
+`CHANGELOG.md` section, but **keep** the attestation link line that
+`build-plugin` adds.
+
+1. Read the new `vX.Y.Z` section from `CHANGELOG.md`.
+2. Read the current draft body and grab the line that starts with
+   `This build has been attested. You can view the attestation details [here](...)`.
+3. Tidy up the changelog markdown (issue/PR links default to `/issues/` —
+   GitHub redirects, but `/pull/` is more accurate; drop the per-line commit
+   SHA links if they feel like noise).
+4. Combine the two and update the draft:
+
+   ```bash
+   gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --notes "$(cat <<'EOF'
+   ## [<VERSION>](https://github.com/grafana/grafana-cube-datasource/compare/v<PREV>...v<VERSION>) (YYYY-MM-DD)
+
+   ### Features
+   ...
+
+   ### Bug Fixes
+   ...
+
+   This build has been attested. You can view the attestation details [here](https://github.com/grafana/grafana-cube-datasource/attestations/<ID>).
+   EOF
+   )"
+   ```
+
+Then publish the draft and mark it as latest:
 
 ```bash
-gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --draft=false
+gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --draft=false --latest
 ```
 
 ## Phase 3 — CD deployment

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -74,9 +74,13 @@ or use a `Release-As: X.Y.Z` footer in a follow-up commit.
 gh pr merge <PR> --repo grafana/grafana-cube-datasource --squash --delete-branch
 ```
 
-Merging tags `vX.Y.Z`, which triggers `release.yml` to build a **draft**
-GitHub release with signed plugin artefacts, SHA checksums and provenance
-attestation. Wait for that workflow:
+Merging tags `vX.Y.Z`, which triggers `release.yml`. The workflow builds
+signed plugin artefacts, SHA checksums and provenance attestation, then
+restores the matching `CHANGELOG.md` section as the release body, preserves
+the attestation link added by `build-plugin`, and publishes the release as
+latest.
+
+Wait for the workflow to finish:
 
 ```bash
 gh run list --workflow=release.yml --limit 1 \
@@ -84,36 +88,9 @@ gh run list --workflow=release.yml --limit 1 \
   --json status,conclusion,displayTitle
 ```
 
-**Edit the draft's release notes** before publishing — the
-`grafana/plugin-actions/build-plugin` action populates the body with submission
-boilerplate that's irrelevant to consumers. Replace it with the matching
-`CHANGELOG.md` section, but **keep** the attestation link line that
-`build-plugin` adds.
-
-1. Read the new `vX.Y.Z` section from `CHANGELOG.md`.
-2. Read the current draft body and grab the line that starts with
-   `This build has been attested. You can view the attestation details [here](...)`.
-3. Tidy up the changelog markdown (issue/PR links default to `/issues/` —
-   GitHub redirects, but `/pull/` is more accurate; drop the per-line commit
-   SHA links if they feel like noise).
-4. Combine the two and update the draft:
-
-   ```bash
-   gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --notes "$(cat <<'EOF'
-   ## [<VERSION>](https://github.com/grafana/grafana-cube-datasource/compare/v<PREV>...v<VERSION>) (YYYY-MM-DD)
-
-   ### Features
-   ...
-
-   ### Bug Fixes
-   ...
-
-   This build has been attested. You can view the attestation details [here](https://github.com/grafana/grafana-cube-datasource/attestations/<ID>).
-   EOF
-   )"
-   ```
-
-Then publish the draft and mark it as latest:
+If the workflow fails on the publish step, the release is left as a draft
+with the build-plugin boilerplate body — fix forward by either rerunning the
+workflow or manually publishing:
 
 ```bash
 gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --draft=false --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@
 #   - Provenance attestation
 #
 # Note: build-plugin replaces the release body with submission boilerplate and
-# flips the release back to draft. The release skill
-# (.cursor/skills/release/SKILL.md) covers restoring the changelog content
-# before publishing.
+# flips the release back to draft. The final step in this workflow restores
+# the matching CHANGELOG.md section as the release body, preserves the
+# attestation link, and publishes the release as latest.
 #
 # For more information, see https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md
 
@@ -54,3 +54,41 @@ jobs:
           attestation: true
           go-version: '1.25'
           node-version: '24'
+
+      - name: Publish release with CHANGELOG.md as body
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+
+          awk -v ver="${VERSION}" '
+            BEGIN {
+              esc = ver
+              gsub(/\./, "\\.", esc)
+              pat = "^## (\\[)?" esc "(\\]| |$)"
+            }
+            /^## / {
+              if (printing) exit
+              if ($0 ~ pat) { printing = 1 }
+            }
+            printing
+          ' CHANGELOG.md > release_body.md
+
+          if [ ! -s release_body.md ]; then
+            echo "::error::No CHANGELOG.md entry found for ${VERSION}"
+            exit 1
+          fi
+
+          ATTESTATION=$(gh release view "${REF_NAME}" --json body --jq '.body' \
+            | grep -F "attestation details" || true)
+          if [ -n "${ATTESTATION}" ]; then
+            printf '\n%s\n' "${ATTESTATION}" >> release_body.md
+          fi
+
+          gh release edit "${REF_NAME}" \
+            --notes-file release_body.md \
+            --draft=false \
+            --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,20 @@
-# Creates GitHub releases with downloadable artifacts when version tags are pushed.
+# Attaches signed artifacts to GitHub releases when version tags are pushed.
 # This runs in addition to the CD workflow (publish.yaml) which publishes to the Grafana catalog.
 #
 # To create a release: merge the release PR opened by the "Release Please"
 # workflow (.github/workflows/release-please.yml). Merging that PR bumps the npm
-# version, updates CHANGELOG.md and pushes a v* tag — which is what triggers
-# this workflow.
+# version, updates CHANGELOG.md, pushes a v* tag, and creates a GitHub release
+# (with the changelog as the body) — the tag push is what triggers this workflow.
 #
-# The workflow will create a draft GitHub release with:
+# This workflow then updates that release with:
 #   - Signed plugin zip files for all platforms
 #   - SHA checksums
 #   - Provenance attestation
+#
+# Note: build-plugin replaces the release body with submission boilerplate and
+# flips the release back to draft. The release skill
+# (.cursor/skills/release/SKILL.md) covers restoring the changelog content
+# before publishing.
 #
 # For more information, see https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md
 


### PR DESCRIPTION
## Summary

Cuts the manual "edit draft body, mark as latest" step out of the release process by adding a final step to `release.yml` that:

- Extracts the matching version's section from `CHANGELOG.md`
- Preserves the attestation link that `build-plugin` added
- Publishes the release as latest

This was previously done manually for v0.6.0 — see [the published release](https://github.com/grafana/grafana-cube-datasource/releases/tag/v0.6.0) for what the output looks like.

Also tightens up the comment in `release.yml` to reflect what actually happens (release-please creates the release first; this workflow updates it) and updates the release skill so it no longer documents the manual step.

## Test plan

Will be exercised on the next release. If the publish step fails, the release is left as a draft with build-plugin's boilerplate body — fix forward by either rerunning the workflow or running:

```bash
gh release edit v<VERSION> --repo grafana/grafana-cube-datasource --draft=false --latest
```

Smoke-tested the awk extraction locally against both the new release-please format (`## [0.6.0](url) (date)`) and the older hand-written format (`## 0.5.0 (date)`) — both extract cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release pipeline and GitHub release publishing behavior; failures could leave releases in draft or with incorrect notes/metadata, but no runtime/plugin code is affected.
> 
> **Overview**
> Automates the final GitHub release publishing step in `release.yml` by extracting the matching version section from `CHANGELOG.md`, preserving the build-plugin-generated attestation link, and updating the existing release to be **non-draft** and marked **latest**.
> 
> Updates the release runbook (`.cursor/skills/release/SKILL.md`) to reflect the new workflow behavior and the manual fallback command (now including `--latest`) if the publish step fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5531248e9e68926b2ee61fb3818f66c977da2eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->