### PR TITLE
chore: follow-up supply-chain hardening after #341

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@cubejs-client/core": "1.6.43",
         "@grafana/eslint-config": "9.0.0",
         "@grafana/plugin-e2e": "3.7.0",
-        "@grafana/sign-plugin": "^3.2.2",
+        "@grafana/sign-plugin": "3.2.2",
         "@grafana/tsconfig": "2.1.0",
         "@playwright/test": "1.59.1",
         "@stylistic/eslint-plugin-ts": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "lint:fix": "npm run lint -- --fix && prettier --write --list-different .",
     "e2e": "playwright test",
     "server": "docker compose up --build",
-    "sign": "sign-plugin",
-    "postinstall": "rm -rf node_modules/flatted/golang"
+    "sign": "sign-plugin"
   },
   "author": "Grafana",
   "license": "AGPL-3.0",
@@ -20,7 +19,7 @@
     "@cubejs-client/core": "1.6.43",
     "@grafana/eslint-config": "9.0.0",
     "@grafana/plugin-e2e": "3.7.0",
-    "@grafana/sign-plugin": "^3.2.2",
+    "@grafana/sign-plugin": "3.2.2",
     "@grafana/tsconfig": "2.1.0",
     "@playwright/test": "1.59.1",
     "@stylistic/eslint-plugin-ts": "4.4.1",


### PR DESCRIPTION
Follow-up to #341, which landed the bulk of the npm supply-chain hardening (`ignore-scripts=true`, `min-release-age=3`, `save-exact=true`, `engine-strict=true`, registry pin, and switching `sign` to the local `sign-plugin` binary).

This PR closes the two gaps that #341 left behind. The branch was rebased onto current `main`, so it no longer carries the now-redundant `.npmrc` rewrite or the stale `npx --yes @grafana/sign-plugin@latest` script (both already handled by #341).

## Changes

- **Remove dead `postinstall` script.** `package.json` still had `"postinstall": "rm -rf node_modules/flatted/golang"`, which can never run under `ignore-scripts=true`. A postinstall that cannot run is worse than no postinstall, so it's removed.
- **Pin `@grafana/sign-plugin` to an exact version.** #341 added it as `^3.2.2`; the repo policy (`.cursor/rules/dependencies.mdc`) and `save-exact=true` require exact pins for deterministic builds and Renovate. Now `3.2.2`.

## Not done: `allow-git=none`

`#341`'s `.npmrc` deliberately omits `allow-git=none`. I investigated enforcing it and chose not to:

- The blocking git dependency is `react-data-grid`, pinned as `git+ssh://git@github.com/grafana/react-data-grid.git#a10c748...`. It is declared in the **published manifest of `@grafana/ui@13.0.1`** (not `@grafana/plugin-ui`, as originally assumed), which is the latest stable release.
- Enforcing `allow-git=none` would require an npm `override` forcing `react-data-grid` to a public registry version, which risks breaking `@grafana/ui`'s DataGrid (the fork exists precisely because the published package differs).
- The git dep is a first-party Grafana fork pinned to an exact commit SHA, so the supply-chain risk is low. The documented exception in `.npmrc` is the pragmatic choice until `@grafana/ui` resolves `react-data-grid` from the registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: no runtime or auth logic changes; only install lifecycle and a devDependency version pin, with a small chance the removed postinstall cleanup was masking a transitive dependency issue.
> 
> **Overview**
> Hardens the install path against supply-chain risk by **removing the `postinstall` script** that previously ran `rm -rf node_modules/flatted/golang` after every `npm install`. Project-defined lifecycle scripts no longer run as part of the default install flow for this repo.
> 
> **Pins `@grafana/sign-plugin`** from `^3.2.2` to exact `3.2.2` in `package.json` and the lockfile so installs resolve a fixed version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 696c9d82fb72ad2d3b5b7a1807d9947ffbf76f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->