### PR TITLE
ci: declare explicit permissions for conventional-commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   check-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:


### PR DESCRIPTION
## Summary

`conventional-commits.yml` was the only workflow without a `permissions:` block, so it ran with the repository's default `GITHUB_TOKEN` permissions. This adds an explicit, least-privilege grant.

`amannn/action-semantic-pull-request` only **reads** the PR title to validate it (no comment/status-writing features are configured), so `pull-requests: read` is sufficient.

## Why

This is the prerequisite for safely switching the repository's **default workflow permissions** from "Read and write" to read-only. Once every workflow declares the write scopes it needs at the job level (the pattern established in #341), the permissive default token can be tightened with no risk of breaking a workflow that was silently relying on it.

## Test plan

- [ ] The Conventional Commits check still passes on this PR (it reads the title using the scoped token)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that narrows token permissions; no application or security logic is modified.
> 
> **Overview**
> Adds a job-level **`permissions:`** block to the Conventional Commits workflow with **`pull-requests: read`**, matching the least-privilege pattern used in other workflows.
> 
> This was the only workflow still relying on the repo default **`GITHUB_TOKEN`** scope. Scoping the token lets the repository default workflow permissions move to read-only without breaking the semantic PR title check (which only needs to read the PR title).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab35f94cfcbbebf86672700b1ed5a09d57f2390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->