### PR TITLE
fix: preserve template-variable filters in the visual editor

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -11,7 +11,11 @@ import { OrderBy } from './OrderBy/OrderBy';
 import { FilterField } from './FilterField/FilterField';
 import { useQueryEditorHandlers } from '../hooks/useQueryEditorHandlers';
 import { buildCubeQueryJson } from '../utils/buildCubeQuery';
-import { detectUnsupportedFeatures, getUnsupportedQueryKeys } from '../utils/detectUnsupportedFeatures';
+import {
+  detectUnsupportedFeatures,
+  filterValuesContainTemplateVariable,
+  getUnsupportedQueryKeys,
+} from '../utils/detectUnsupportedFeatures';
 import { decorateWithViewSelection, getViewSelectionState } from '../utils/viewSelection';
 import { UnsupportedFieldsViewer } from './UnsupportedFieldsViewer';
 
@@ -216,7 +220,8 @@ function VisualQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
       >
         <FilterField
           filters={query.filters?.filter(
-            (f): f is CubeFilter => isCubeFilter(f) && VISUAL_BUILDER_OPERATORS.has(f.operator)
+            (f): f is CubeFilter =>
+              isCubeFilter(f) && VISUAL_BUILDER_OPERATORS.has(f.operator) && !filterValuesContainTemplateVariable(f)
           )}
           dimensions={dimensionOptions}
           onChange={onFiltersChange}

--- a/src/hooks/useQueryEditorHandlers.test.ts
+++ b/src/hooks/useQueryEditorHandlers.test.ts
@@ -59,6 +59,62 @@ describe('useQueryEditorHandlers', () => {
       expect(updatedQuery.filters).toEqual([advancedFilter]);
     });
 
+    it('should preserve template-variable filters even though they use a visual operator', () => {
+      // A dashboard-variable filter uses the equals operator (a visual operator),
+      // but its $var value can't be rendered as a selectable chip, so it must be
+      // preserved here rather than relying on FilterField's callback list.
+      const templateVarFilter = { member: 'orders.status', operator: Operator.Equals, values: ['$statusVar'] };
+      const visualFilter = { member: 'orders.region', operator: Operator.Equals, values: ['US'] };
+
+      const query: CubeQuery = {
+        refId: 'A',
+        filters: [visualFilter, templateVarFilter],
+      };
+
+      const onChange = jest.fn();
+      const onRunQuery = jest.fn();
+
+      const { result } = renderHook(() => useQueryEditorHandlers(query, onChange, onRunQuery));
+
+      const updatedVisualFilter = { member: 'orders.region', operator: Operator.Equals, values: ['EU'] };
+      act(() => {
+        result.current.onFiltersChange([updatedVisualFilter]);
+      });
+
+      const updatedQuery = onChange.mock.calls[0][0];
+      expect(updatedQuery.filters).toContainEqual(updatedVisualFilter);
+      expect(updatedQuery.filters).toContainEqual(templateVarFilter);
+      expect(updatedQuery.filters).toHaveLength(2);
+    });
+
+    it('should preserve template-variable filters with ${var:format} and [[var]] syntaxes when visual filters are emptied', () => {
+      const formatVarFilter = { member: 'orders.status', operator: Operator.NotEquals, values: ['${statusVar:csv}'] };
+      const legacyVarFilter = { member: 'orders.region', operator: Operator.Equals, values: ['[[regionVar]]'] };
+
+      const query: CubeQuery = {
+        refId: 'A',
+        filters: [
+          { member: 'orders.country', operator: Operator.Equals, values: ['US'] },
+          formatVarFilter,
+          legacyVarFilter,
+        ],
+      };
+
+      const onChange = jest.fn();
+      const onRunQuery = jest.fn();
+
+      const { result } = renderHook(() => useQueryEditorHandlers(query, onChange, onRunQuery));
+
+      act(() => {
+        result.current.onFiltersChange([]);
+      });
+
+      const updatedQuery = onChange.mock.calls[0][0];
+      expect(updatedQuery.filters).toContainEqual(formatVarFilter);
+      expect(updatedQuery.filters).toContainEqual(legacyVarFilter);
+      expect(updatedQuery.filters).toHaveLength(2);
+    });
+
     it('should clear filters entirely when no filters remain', () => {
       const query: CubeQuery = {
         refId: 'A',

--- a/src/hooks/useQueryEditorHandlers.ts
+++ b/src/hooks/useQueryEditorHandlers.ts
@@ -3,6 +3,7 @@ import { ChangeEvent } from 'react';
 import { CubeQuery, CubeFilter, CubeFilterItem, Order, DEFAULT_ORDER, VISUAL_BUILDER_OPERATORS, isCubeFilter } from '../types';
 import { SelectableValue } from '@grafana/data';
 import { normalizeOrder } from '../utils/normalizeOrder';
+import { filterValuesContainTemplateVariable } from '../utils/detectUnsupportedFeatures';
 
 export function useQueryEditorHandlers(query: CubeQuery, onChange: (query: CubeQuery) => void, onRunQuery: () => void) {
   const updateQueryAndRun = (updates: Partial<CubeQuery>) => {
@@ -88,10 +89,13 @@ export function useQueryEditorHandlers(query: CubeQuery, onChange: (query: CubeQ
 
   const onFiltersChange = (filters: CubeFilter[]) => {
     // The visual FilterField only edits equals/notEquals filters. Preserve any
-    // non-visual-builder filters (advanced operators, AND/OR groups,
-    // template-variable filters) so editing in the visual builder doesn't drop them.
+    // non-visual-builder filters (advanced operators, AND/OR groups) so editing
+    // in the visual builder doesn't drop them. Template-variable filters use a
+    // visual operator (e.g. equals) but their $var value can't be represented as
+    // a selectable chip, so FilterField may drop them on edit — keep those too.
     const nonVisualFilters = (query.filters ?? []).filter(
-      (f: CubeFilterItem) => !isCubeFilter(f) || !VISUAL_BUILDER_OPERATORS.has(f.operator)
+      (f: CubeFilterItem) =>
+        !isCubeFilter(f) || !VISUAL_BUILDER_OPERATORS.has(f.operator) || filterValuesContainTemplateVariable(f)
     );
     const merged = [...filters, ...nonVisualFilters];
     updateQueryAndRun({ filters: merged.length > 0 ? merged : undefined });

--- a/src/utils/detectUnsupportedFeatures.ts
+++ b/src/utils/detectUnsupportedFeatures.ts
@@ -1,6 +1,18 @@
-import { CubeFilterItem, CubeQuery, VISUAL_BUILDER_OPERATORS, isCubeFilter, isCubeAndFilter, isCubeOrFilter } from '../types';
+import { CubeFilter, CubeFilterItem, CubeQuery, VISUAL_BUILDER_OPERATORS, isCubeFilter, isCubeAndFilter, isCubeOrFilter } from '../types';
 
-const TEMPLATE_VARIABLE_PATTERN = /(?:\$(?:[a-zA-Z_]\w*|\{[a-zA-Z_]\w*(?::[^}]+)?\})|\[\[[^\]]+\]\])/;
+/**
+ * Matches Grafana template variable syntax in a string: $var, ${var},
+ * ${var:format}, or [[var]]. Shared so filter handling and unsupported-feature
+ * detection agree on what counts as a dashboard-variable value.
+ */
+export const TEMPLATE_VARIABLE_PATTERN = /(?:\$(?:[a-zA-Z_]\w*|\{[a-zA-Z_]\w*(?::[^}]+)?\})|\[\[[^\]]+\]\])/;
+
+/**
+ * Whether any of a flat filter's values contains a Grafana template variable.
+ */
+export function filterValuesContainTemplateVariable(filter: CubeFilter): boolean {
+  return filter.values?.some((v) => TEMPLATE_VARIABLE_PATTERN.test(v)) ?? false;
+}
 
 /**
  * Detects query features that the visual builder cannot represent.
@@ -103,7 +115,7 @@ function collectAdvancedOperators(filters: CubeFilterItem[]): string[] {
 function hasTemplateVariableInFilterValues(filters: CubeFilterItem[]): boolean {
   for (const item of filters) {
     if (isCubeFilter(item)) {
-      if (item.values?.some((v) => TEMPLATE_VARIABLE_PATTERN.test(v))) {
+      if (filterValuesContainTemplateVariable(item)) {
         return true;
       }
     } else if (isCubeAndFilter(item)) {


### PR DESCRIPTION
## Summary

Fixes the Cursor Bugbot finding on #351 ([review comment](https://github.com/grafana/grafana-cube-datasource/pull/351#pullrequestreview-4423307458)): **template-variable filters were silently dropped** when editing in the visual builder.

A dashboard-variable filter such as `{ member: 'orders.status', operator: equals, values: ['$var'] }` uses `equals` — a *visual* operator — so it was:

- **passed into** the visual `FilterField` (which can't represent `$var` as a selectable value chip), and
- **excluded** from `onFiltersChange`'s preserved non-visual set.

So editing any filter in the visual builder could drop the `$var` filter entirely. (`detectUnsupportedFeatures` already flags these values as unsupported, so the two code paths disagreed.)

## Changes

- **`QueryEditor.tsx`** — exclude template-variable filters from `FilterField`'s input so they're never echoed back by its `onChange` (prevents both dropping *and* duplication).
- **`useQueryEditorHandlers.ts`** — preserve template-variable filters in `onFiltersChange` regardless of operator.
- **`detectUnsupportedFeatures.ts`** — export a shared `TEMPLATE_VARIABLE_PATTERN` + `filterValuesContainTemplateVariable()` helper so detection and filter handling use the same definition.
- **`useQueryEditorHandlers.test.ts`** — new tests covering `$var`, `${var:format}`, and `[[var]]` syntaxes (these fail without the fix).

## Test plan

- `npm run typecheck` clean
- `npm run lint` clean (0 errors)
- `npm run test:ci` — 249 tests pass (+2 new)

## Merge / review note

Targets `experimental`, not `main`. Merged after CI is green with GenAI review only; all code still reaches `main`/releases via the human-reviewed `experimental → main` PR (#352).

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to query editor filter merge/display logic with added unit tests; no auth, data pipeline, or API changes.
> 
> **Overview**
> Fixes **silent loss of dashboard-variable filters** when editing equals/notEquals filters in the Cube visual query builder. Filters like `values: ['$statusVar']` use visual operators but cannot be shown as chips in `FilterField`, so they were both fed into the visual editor and omitted from the merge logic in `onFiltersChange`.
> 
> **QueryEditor** now excludes template-variable filters from `FilterField` input via `filterValuesContainTemplateVariable`, so they are not echoed or duplicated on change. **useQueryEditorHandlers** treats those filters like other preserved non-visual filters when merging visual edits. **detectUnsupportedFeatures** exports shared `TEMPLATE_VARIABLE_PATTERN` and `filterValuesContainTemplateVariable()` so detection and editor behavior use the same Grafana syntax (`$var`, `${var:format}`, `[[var]]`). New handler tests cover preservation when visual filters are updated or cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2173dc770fe9593d1cc6dcd00ecbd71a04e9d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->