### PR TITLE
ci(renovate): stabilise and automerge lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
     "github>grafana/grafana-renovate-config//presets/plugin-ci-workflows"
   ],
   "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "minimumReleaseAgeBehaviour": "timestamp-optional"
+  },
   "packageRules": [
     {
       "groupName": "All non-major dependencies",


### PR DESCRIPTION
## What
- Set `minimumReleaseAgeBehaviour: "timestamp-optional"` for `lockFileMaintenance`.
- Enable `automerge` for `lockFileMaintenance`.

## Why
The Renovate "lock file maintenance" PR (#354) has green CI but its `renovate/stability-days` check is **stuck pending forever** — waiting longer never helps.

Since Renovate v42, `lockFileMaintenance` produces a *virtual* upgrade entry with **no `releaseTimestamp`**. With the default `minimumReleaseAgeBehaviour: timestamp-required`, a missing timestamp is treated as "not yet past `minimumReleaseAge`", so the 3-day cooling-off gate inherited from `grafana-renovate-config//presets/base` can never be satisfied.

`timestamp-optional` skips the cooling-off gate **only** for these timestamp-less lockfile refreshes; real dependency upgrades still get the full 3 days.

`automerge: true` matches the existing automerge posture already configured for non-major dependency updates, so the weekly lockfile refresh no longer needs a manual merge once CI is green.

## Effect
Unblocks #354 and future lock-file-maintenance PRs.

## Notes
- Independent of the prismjs override in the companion PR.
- Does **not** touch the "All non-major dependencies" grouping — that grouped PR (#334) being pending for stretches is expected behaviour (the stability window is the union of all grouped members). Happy to follow up separately if we want to split the group or lower cooling-off for trusted scopes.

https://claude.ai/code/session_01SLhCPYj6DhFe3fUPAbaRNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLhCPYj6DhFe3fUPAbaRNj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Renovate bot configuration changes; no application runtime, auth, or dependency code is modified.
> 
> **Overview**
> Adds a dedicated **`lockFileMaintenance`** block in `renovate.json` so weekly lockfile refresh PRs can finish Renovate’s stability checks and merge automatically.
> 
> **`minimumReleaseAgeBehaviour: "timestamp-optional"`** avoids lockfile maintenance PRs staying pending forever when Renovate v42+ emits virtual upgrades with no `releaseTimestamp` under the preset’s default `timestamp-required` behaviour. Real dependency updates still use the inherited cooling-off period.
> 
> **`automerge: true`** on lockfile maintenance aligns with existing non-major automerge posture so green CI lockfile PRs do not need manual merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3967ca500939a31cc89e7bdf018c7d4e8781e5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->