### PR TITLE
fix(security): override ws to 8.21.0 (CVE-2026-48779)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17135,9 +17135,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -85,12 +85,13 @@
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.16.0",
   "volta": {
     "node": "24.15.0"
   },
   "overrides": {
     "lodash": "4.18.1",
-    "qs": "6.15.2"
+    "qs": "6.15.2",
+    "ws": "8.21.0"
   }
 }


### PR DESCRIPTION
## What
Pin `ws` to `8.21.0` via `overrides` (was resolving to the vulnerable `8.18.3`).

## Why
`ws <= 8.20.1` is vulnerable to **CVE-2026-48779** (HIGH) — a memory-exhaustion DoS where a peer sends high volumes of exceptionally small WebSocket fragments to force memory allocation far beyond the documented message-size limit. Fixed in **8.21.0**.

`osv-scanner` (in the `CI / Test and build plugin` job) fails on this for **every PR and on `main`**, because `ws` sits in the lockfile as a dev-only transitive dependency:

```
jest-environment-jsdom → jsdom → ws@8.18.3
```

## Effect
- Lockfile change is just `ws` 8.18.3 → 8.21.0 (dev-only; not shipped in the plugin bundle).
- Unblocks `CI / Test and build plugin` on `main` and, on their next run, on the open PRs (#358 prismjs override, #359 Renovate config) which currently fail on this exact scan.

## Notes
- Also bumps the npm `packageManager` pin 11.12.1 → 11.16.0 to satisfy the org Supply Chain Security rule (npm >= 11.15.0 required whenever `package.json` is part of a PR diff) — the same rule flagged by Bugbot on #358.
- Renovate would eventually raise its own `ws` security PR; this lands the fix now so CI is green again.

https://claude.ai/code/session_01SLhCPYj6DhFe3fUPAbaRNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLhCPYj6DhFe3fUPAbaRNj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only transitive dependency override with no runtime bundle impact; standard security pinning plus a tooling version bump.
> 
> **Overview**
> Pins transitive **`ws`** to **8.21.0** via npm **`overrides`**, replacing the lockfile’s vulnerable **8.18.3** (from **jest-environment-jsdom → jsdom → ws**). This addresses **CVE-2026-48779** (DoS via tiny WebSocket fragments) and clears **`osv-scanner`** failures in CI; the dependency is **dev-only** and not part of the shipped plugin bundle.
> 
> Also updates the **`packageManager`** pin from **npm@11.12.1** to **npm@11.16.0** so PRs that touch **`package.json`** meet the org npm version requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130e9044b2773ec6662cc5838f01d80ad65713db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->