### PR TITLE
ci(renovate): ungroup non-major dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
   },
   "packageRules": [
     {
-      "groupName": "All non-major dependencies",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "labels": ["automerge"]


### PR DESCRIPTION
## What

Removes the `"groupName": "All non-major dependencies"` from the `packageRule` in `renovate.json`.

## Why

The grouped configuration funnels every minor/patch/pin/digest update into a single combined PR (#334). That PR bumps too many dependencies at once, so it's effectively impossible to get all checks green and merge — any one failing dependency blocks the whole batch.

By removing the `groupName`, Renovate falls back to its default behaviour of opening **one PR per dependency**, so updates can pass CI and merge independently.

## Notes

- `matchUpdateTypes`, `automerge`, and the `automerge` label are unchanged, so individual non-major PRs still automerge once their checks pass.
- No change needed in `grafana/grafana-renovate-config` — the grouping was defined solely in this repo's `renovate.json`, not in the shared `base` preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3xjmrwyweP2WJTgiZ16LZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3xjmrwyweP2WJTgiZ16LZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Renovate grouping; automerge behavior for individual non-major PRs is unchanged.
> 
> **Overview**
> **Renovate** will stop bundling all non-major dependency bumps into a single PR by removing `"groupName": "All non-major dependencies"` from the matching `packageRule` in `renovate.json`.
> 
> Minor, patch, pin, and digest updates still use the same rule (`automerge` and the `automerge` label unchanged); Renovate’s default is now **one PR per dependency**, so CI failures on one package no longer block merging the rest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df47bfca9abb81f30b49f5b63249a12e6df56c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->