### PR TITLE
fix(plugin): make grafanaDependency prerelease-inclusive

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -46,7 +46,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=12.2.5",
+    "grafanaDependency": ">=12.2.5-0",
     "plugins": []
   }
 }


### PR DESCRIPTION
## Summary

Appends `-0` to the `grafanaDependency` lower bound in `src/plugin.json` so the version range matches prerelease Grafana builds (e.g. nightly/`-pre` versions).

```diff
- "grafanaDependency": ">=12.2.5"
+ "grafanaDependency": ">=12.2.5-0"
```

grafana-com PR #17309 made the plugins publish API reject Grafana-owned plugins whose `grafanaDependency` lower bound isn't prerelease-inclusive. Without this change, the next publish of this plugin would be rejected. No behaviour change for released Grafana versions.

Fixes #357

Ref: https://github.com/grafana/grafana-com/pull/17309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yPtmsoGW766EtVU8GKb5B

---
_Generated by [Claude Code](https://claude.ai/code/session_015yPtmsoGW766EtVU8GKb5B)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in plugin.json with no runtime or application logic changes.
> 
> **Overview**
> Updates the **`grafanaDependency`** lower bound in `plugin.json` from `>=12.2.5` to **`>=12.2.5-0`** so the declared range is prerelease-inclusive.
> 
> This aligns with Grafana’s plugins publish validation (grafana-com #17309), which rejects Grafana-owned plugins whose minimum dependency does not include prerelease builds (e.g. nightly / `-pre`). **Released** Grafana versions remain satisfied; the change is mainly so **publish** succeeds and prerelease Grafana installs can match the constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a6c538f2d3b85b096eb3d2edf36ae1d635e4d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->