### PR TITLE
fix: fall back to POST /v1/load for large queries

### DIFF
--- a/pkg/plugin/cubeclient.go
+++ b/pkg/plugin/cubeclient.go
@@ -1,17 +1,27 @@
 package plugin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/grafana/cube/pkg/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
+
+// urlLengthLimit mirrors URL_LENGTH_LIMIT in @cubejs-client/core's HttpTransport.
+// The SDK sends /v1/load requests via GET with the query URL-encoded in the
+// query string, but switches to POST (query in a JSON body) once the full URL
+// reaches this length. Without the fallback, large queries (e.g. a filter with
+// hundreds of values) blow past server-side URL/header limits — Node.js rejects
+// request lines + headers over ~16KB with "431 Request Header Fields Too Large".
+const urlLengthLimit = 2000
 
 // CubeAPIError represents a non-200 HTTP response from the Cube API.
 // It preserves the original status code and body so callers (e.g. handleTagValues)
@@ -25,18 +35,42 @@ func (e *CubeAPIError) Error() string {
 	return fmt.Sprintf("API request failed with status %d: %s", e.StatusCode, string(e.Body))
 }
 
-// doCubeLoadRequest makes a GET request to Cube's /v1/load endpoint, handling the
+// doCubeLoadRequest sends a query to Cube's /v1/load endpoint, handling the
 // "Continue wait" polling protocol. Cube returns {"error": "Continue wait"} (HTTP 200)
 // when query results aren't cached yet (e.g. the upstream warehouse is still computing).
 // This method retries immediately until actual data arrives or the context is cancelled, matching the
 // behavior of the official @cubejs-client/core SDK.
-func (d *Datasource) doCubeLoadRequest(ctx context.Context, requestURL string, config *models.PluginSettings) ([]byte, error) {
+//
+// SDK alignment: like @cubejs-client/core, the query is sent via GET with the
+// query JSON URL-encoded in the query string while the full URL stays under
+// urlLengthLimit, and via POST with a {"query": ...} JSON body otherwise.
+func (d *Datasource) doCubeLoadRequest(ctx context.Context, loadURL string, queryJSON []byte, config *models.PluginSettings) ([]byte, error) {
+	params := url.Values{}
+	params.Add("query", string(queryJSON))
+	getURL := loadURL + "?" + params.Encode()
+
+	usePost := len(getURL) >= urlLengthLimit
+	var postBody []byte
+	if usePost {
+		var err error
+		postBody, err = json.Marshal(map[string]json.RawMessage{"query": queryJSON})
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+	}
+
 	pollStart := time.Now()
 	pollRetries := 0
 	var lastContinueWaitProgress continueWaitProgress
 	haveContinueWaitProgress := false
 	for {
-		req, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+		var req *http.Request
+		var err error
+		if usePost {
+			req, err = http.NewRequestWithContext(ctx, "POST", loadURL, bytes.NewReader(postBody))
+		} else {
+			req, err = http.NewRequestWithContext(ctx, "GET", getURL, nil)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
@@ -87,11 +121,11 @@ func (d *Datasource) doCubeLoadRequest(ctx context.Context, requestURL string, c
 			haveContinueWaitProgress = true
 
 			if pollRetries == 0 {
-				backend.Logger.Info("Cube query not yet ready, polling for results", "url", requestURL)
+				backend.Logger.Info("Cube query not yet ready, polling for results", "url", loadURL)
 			}
 			pollRetries++
 			backend.Logger.Debug("Cube returned 'Continue wait', polling again",
-				"url", requestURL, "attempt", pollRetries,
+				"url", loadURL, "attempt", pollRetries,
 				"stage", progress.Stage, "cubeTimeElapsed", progress.TimeElapsed)
 			select {
 			case <-ctx.Done():
@@ -111,7 +145,7 @@ func (d *Datasource) doCubeLoadRequest(ctx context.Context, requestURL string, c
 		}
 
 		if pollRetries > 0 {
-			backend.Logger.Info("Cube query results ready after polling", "url", requestURL, "retries", pollRetries, "duration", time.Since(pollStart).Round(time.Millisecond))
+			backend.Logger.Info("Cube query results ready after polling", "url", loadURL, "retries", pollRetries, "duration", time.Since(pollStart).Round(time.Millisecond))
 		}
 
 		return body, nil

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -103,23 +102,14 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 		return backend.ErrDataResponse(backend.StatusBadRequest, err.Error())
 	}
 
-	// Add query parameter
-	u, err := url.Parse(apiReq.URL.String())
-	if err != nil {
-		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("Failed to parse API URL: %v", err))
-	}
-
-	params := url.Values{}
-	params.Add("query", string(cubeAPIQueryJSON))
-	u.RawQuery = params.Encode()
-
 	// Debug: Log what we're sending to the API
-	backend.Logger.Debug("Making API request", "url", u.String(), "cubeQuery", string(cubeAPIQueryJSON))
+	backend.Logger.Debug("Making API request", "url", apiReq.URL.String(), "cubeQuery", string(cubeAPIQueryJSON))
 
-	// Use shared helper to make the request with "Continue wait" polling
-	body, err := d.doCubeLoadRequest(ctx, u.String(), apiReq.Config)
+	// Use shared helper to make the request with "Continue wait" polling.
+	// The helper picks GET or POST based on the encoded query size.
+	body, err := d.doCubeLoadRequest(ctx, apiReq.URL.String(), cubeAPIQueryJSON, apiReq.Config)
 	if err != nil {
-		backend.Logger.Error("Failed to fetch data from Cube API", "error", err, "url", u.String())
+		backend.Logger.Error("Failed to fetch data from Cube API", "error", err, "url", apiReq.URL.String())
 		return backend.ErrDataResponse(backend.StatusBadRequest, err.Error())
 	}
 

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -189,6 +189,171 @@ func TestQueryDataWithCubeQuery(t *testing.T) {
 	}
 }
 
+// TestQueryDataMethodSelection verifies SDK-aligned method selection: queries
+// are sent via GET while the URL stays under the SDK's 2000-char limit, and
+// via POST with a {"query": ...} JSON body otherwise (matching
+// @cubejs-client/core's HttpTransport). Without the POST fallback, servers
+// reject large GET URLs (e.g. Node.js responds 431 past its header limit).
+func TestQueryDataMethodSelection(t *testing.T) {
+	manyValues := make([]string, 200)
+	for i := range manyValues {
+		manyValues[i] = fmt.Sprintf("005%015d", i)
+	}
+
+	tests := []struct {
+		name           string
+		filterValues   []string
+		expectedMethod string
+	}{
+		{name: "small query uses GET", filterValues: []string{"26"}, expectedMethod: "GET"},
+		{name: "large query falls back to POST", filterValues: manyValues, expectedMethod: "POST"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.expectedMethod {
+					t.Errorf("Expected %s request, got %s", tt.expectedMethod, r.Method)
+				}
+
+				// Extract the Cube query from wherever the method carries it
+				var queryJSON string
+				if r.Method == "GET" {
+					queryJSON = r.URL.Query().Get("query")
+				} else {
+					var body struct {
+						Query json.RawMessage `json:"query"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Errorf("Failed to decode POST body: %v", err)
+					}
+					queryJSON = string(body.Query)
+				}
+
+				var cubeQuery CubeQuery
+				if err := json.Unmarshal([]byte(queryJSON), &cubeQuery); err != nil {
+					t.Errorf("Failed to parse cube query: %v", err)
+				}
+				if len(cubeQuery.Filters) != 1 {
+					t.Errorf("Expected 1 filter, got %d", len(cubeQuery.Filters))
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(CubeAPIResponse{
+					Data: []map[string]interface{}{{"orders.count": "42"}},
+					Annotation: CubeAnnotation{
+						Measures: map[string]CubeFieldInfo{"orders.count": {Title: "Count", ShortTitle: "Count", Type: "number"}},
+					},
+				})
+			}))
+			defer server.Close()
+
+			ds := Datasource{BaseURL: server.URL}
+
+			queryJSON, _ := json.Marshal(map[string]interface{}{
+				"refId":    "A",
+				"measures": []string{"orders.count"},
+				"filters": []map[string]interface{}{
+					{"member": "orders.user_id", "operator": "equals", "values": tt.filterValues},
+				},
+			})
+
+			resp, err := ds.QueryData(
+				context.Background(),
+				&backend.QueryDataRequest{
+					PluginContext: newTestPluginContext(server.URL),
+					Queries: []backend.DataQuery{
+						{RefID: "A", JSON: queryJSON},
+					},
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := resp.Responses["A"]
+			if result.Error != nil {
+				t.Fatalf("Expected no error, got: %v", result.Error)
+			}
+			if len(result.Frames) != 1 || result.Frames[0].Fields[0].Len() != 1 {
+				t.Fatalf("Expected 1 frame with 1 row")
+			}
+		})
+	}
+}
+
+// TestQueryDataLargeQueryContinueWaitRepostsBody verifies that the POST body
+// is re-sent on every "Continue wait" polling retry (each retry needs a fresh
+// body reader).
+func TestQueryDataLargeQueryContinueWaitRepostsBody(t *testing.T) {
+	manyValues := make([]string, 200)
+	for i := range manyValues {
+		manyValues[i] = fmt.Sprintf("005%015d", i)
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.Method != "POST" {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+
+		var body struct {
+			Query CubeQuery `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("Request %d: failed to decode POST body: %v", requestCount, err)
+		}
+		if len(body.Query.Measures) != 1 {
+			t.Errorf("Request %d: expected 1 measure in re-sent body, got %d", requestCount, len(body.Query.Measures))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if requestCount == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"error": "Continue wait"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CubeAPIResponse{
+			Data: []map[string]interface{}{{"orders.count": "42"}},
+			Annotation: CubeAnnotation{
+				Measures: map[string]CubeFieldInfo{"orders.count": {Title: "Count", ShortTitle: "Count", Type: "number"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ds := Datasource{BaseURL: server.URL}
+
+	queryJSON, _ := json.Marshal(map[string]interface{}{
+		"refId":    "A",
+		"measures": []string{"orders.count"},
+		"filters": []map[string]interface{}{
+			{"member": "orders.user_id", "operator": "equals", "values": manyValues},
+		},
+	})
+
+	resp, err := ds.QueryData(
+		context.Background(),
+		&backend.QueryDataRequest{
+			PluginContext: newTestPluginContext(server.URL),
+			Queries: []backend.DataQuery{
+				{RefID: "A", JSON: queryJSON},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := resp.Responses["A"]
+	if result.Error != nil {
+		t.Fatalf("Expected no error, got: %v", result.Error)
+	}
+	if requestCount != 2 {
+		t.Fatalf("Expected 2 requests (1 continue-wait + 1 success), got %d", requestCount)
+	}
+}
+
 func TestQueryDataContinueWaitThenSuccess(t *testing.T) {
 	// Cube returns {"error": "Continue wait"} (HTTP 200) when query results
 	// aren't cached yet. The plugin must poll until data is ready.

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -264,18 +264,9 @@ func (d *Datasource) handleTagValues(ctx context.Context, req *backend.CallResou
 		return sender.Send(jsonErrorResponse(500, fmt.Errorf("failed to build API URL: %w", err)))
 	}
 
-	// Add query parameter
-	u, err := url.Parse(apiReq.URL.String())
-	if err != nil {
-		return sender.Send(jsonErrorResponse(500, errors.New("failed to parse API URL")))
-	}
-
-	params := url.Values{}
-	params.Add("query", string(cubeQueryJSON))
-	u.RawQuery = params.Encode()
-
-	// Use shared helper to make the request with "Continue wait" polling
-	body, err := d.doCubeLoadRequest(ctx, u.String(), apiReq.Config)
+	// Use shared helper to make the request with "Continue wait" polling.
+	// The helper picks GET or POST based on the encoded query size.
+	body, err := d.doCubeLoadRequest(ctx, apiReq.URL.String(), cubeQueryJSON, apiReq.Config)
 	if err != nil {
 		backend.Logger.Error("Failed to fetch tag values from Cube API", "error", err)
 		// If this is a Cube API error (non-200), forward the original status code and body


### PR DESCRIPTION
## Summary

- Mirror `@cubejs-client/core`'s `HttpTransport` method selection: send `/v1/load` queries via GET while the full URL stays under the SDK's 2000-char `URL_LENGTH_LIMIT`, and via POST with a `{"query": ...}` JSON body otherwise ([SDK source](https://github.com/cube-js/cube/blob/master/packages/cubejs-client-core/src/HttpTransport.js), [REST API docs](https://docs.cube.dev/reference/core-data-apis/rest-api/reference#base_pathv1load)).
- Applies to both the query data path and the AdHoc tag-values path via the shared `doCubeLoadRequest` helper.
- The POST body is rebuilt on each "Continue wait" polling retry so the request can be safely re-sent.

## Why

Previously every load request was a GET with the query URL-encoded in the query string. A query with many filter values — e.g. a multi-value dashboard variable with "All" selected expanding to hundreds of IDs — pushes the request line past Node.js's ~16KB header limit, and Cube rejects it with `431 Request Header Fields Too Large` before ever parsing the query. Reproduced against a live Cube instance: an equals filter with 971 values (≈21KB encoded) consistently returns 431 via GET and succeeds via POST.

## Test plan

- [x] `go test ./pkg/...` — new `TestQueryDataMethodSelection` covers GET (small query) and POST (large query, body shape) paths
- [x] New `TestQueryDataLargeQueryContinueWaitRepostsBody` verifies the body is re-sent on Continue-wait retries
- [x] Existing protocol tests (Continue wait polling, error forwarding, cancellation) unchanged and green

Made with [Cursor](https://cursor.com)