### PR TITLE
fix(adhoc): drop AdHoc filters inapplicable to a query's Cube view (#307)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ AdHoc filters can also be edited directly in the dashboard UI to add additional 
 - Multiple AdHoc filters combine with AND (intersection)
 - AdHoc filters combine with per-panel filters using AND (intersection)
 
+> **AdHoc filters are scoped to a single Cube view.** Cube views are sealed namespaces — every member is fully qualified by its view (e.g. `view_a.region`, never just `region`). An AdHoc filter therefore only applies to panels whose query targets the **same view** as the filter's member; it is automatically dropped from queries on other views (which would otherwise error). In practice, clicking `customer = BBC` on a `view_a` panel filters only the `view_a` panels on the dashboard — `view_b` panels are left unfiltered. When a filter is dropped, the panel's SQL preview shows a "Skipped N inapplicable AdHoc filter(s)" hint. Cross-view (business-level) filtering would require explicit cross-view equivalence in the data model and is tracked as a follow-up.
+
 #### Time Range Filtering
 
 To filter all panels by the dashboard time picker:

--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -878,13 +878,19 @@ describe('QueryEditor', () => {
       });
 
       const datasource = createMockDataSource();
+      // Genuinely cold: the synchronous cache is empty until getMetadata resolves,
+      // so the initial render must NOT scope (dropped list empty) and the dropped
+      // filter should appear ONLY after the async metadata load (deferred rerender).
+      datasource.getCachedMetadata = jest.fn().mockReturnValue(null);
       const query = createMockQuery({ dimensions: ['orders.status'], measures: ['orders.count'] });
 
       setup(<QueryEditor query={query} onChange={mockOnChange} onRunQuery={mockOnRunQuery} datasource={datasource} />);
 
-      // getMetadata resolves asynchronously via react-query; the memo must
-      // recompute and thread the dropped (cross-view) filter through once the
-      // view metadata is available (deferred rerender).
+      // Before metadata resolves: no scoping yet (cold cache -> inject-all).
+      expect(screen.getByTestId('dropped-adhoc')).toHaveTextContent('');
+
+      // After the async getMetadata resolves via react-query, the memo recomputes
+      // and threads the dropped (cross-view) filter through.
       await waitFor(() => expect(screen.getByTestId('dropped-adhoc')).toHaveTextContent('other.region'));
     });
 

--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -6,9 +6,15 @@ import { CubeQuery, Operator } from '../types';
 import { getTemplateSrv } from '@grafana/runtime';
 import { createMockDataSource, setup } from '../testUtils';
 
-// Mock the SQLPreview component
+// Mock the SQLPreview component. Also expose droppedAdHocFilters so tests can
+// assert the #307 view-scoping result is threaded through reactively.
 jest.mock('./SQLPreview', () => ({
-  SQLPreview: ({ sql }: { sql: string }) => <div data-testid="sql-preview">{sql}</div>,
+  SQLPreview: ({ sql, droppedAdHocFilters = [] }: { sql: string; droppedAdHocFilters?: Array<{ member: string }> }) => (
+    <div data-testid="sql-preview">
+      {sql}
+      <span data-testid="dropped-adhoc">{droppedAdHocFilters.map((f) => f.member).join(',')}</span>
+    </div>
+  ),
 }));
 
 // Mock @grafana/runtime for getTemplateSrv
@@ -863,6 +869,41 @@ describe('QueryEditor', () => {
     });
   });
 
+  describe('AdHoc view-scoping hint (issue #307)', () => {
+    it('shows the "Skipped N" hint once metadata loads (deferred rerender)', async () => {
+      // AdHoc filter targets a member outside this query's "orders" view.
+      mockGetTemplateSrv.mockReturnValue({
+        replace: jest.fn((value: string) => value),
+        getAdhocFilters: jest.fn(() => [{ key: 'other.region', operator: '=', value: 'US' }]),
+      });
+
+      const datasource = createMockDataSource();
+      const query = createMockQuery({ dimensions: ['orders.status'], measures: ['orders.count'] });
+
+      setup(<QueryEditor query={query} onChange={mockOnChange} onRunQuery={mockOnRunQuery} datasource={datasource} />);
+
+      // getMetadata resolves asynchronously via react-query; the memo must
+      // recompute and thread the dropped (cross-view) filter through once the
+      // view metadata is available (deferred rerender).
+      await waitFor(() => expect(screen.getByTestId('dropped-adhoc')).toHaveTextContent('other.region'));
+    });
+
+    it('shows no hint when the AdHoc filter belongs to the query view', async () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: jest.fn((value: string) => value),
+        getAdhocFilters: jest.fn(() => [{ key: 'orders.region', operator: '=', value: 'US' }]),
+      });
+
+      const datasource = createMockDataSource();
+      const query = createMockQuery({ dimensions: ['orders.status'], measures: ['orders.count'] });
+
+      setup(<QueryEditor query={query} onChange={mockOnChange} onRunQuery={mockOnRunQuery} datasource={datasource} />);
+
+      await waitFor(() => expect(datasource.getMetadata).toHaveBeenCalled());
+      expect(screen.getByTestId('dropped-adhoc')).toHaveTextContent('');
+    });
+  });
+
   describe('unsupported features detection', () => {
     it('should show JSON viewer when query has time dimensions', async () => {
       const datasource = createMockDataSource();
@@ -883,8 +924,9 @@ describe('QueryEditor', () => {
       expect(screen.queryByText('Select dimensions...')).not.toBeInTheDocument();
       expect(screen.queryByText('Select measures...')).not.toBeInTheDocument();
 
-      // Should NOT fetch metadata (visual builder not rendered)
-      expect(datasource.getMetadata).not.toHaveBeenCalled();
+      // Metadata IS fetched even in JSON mode so the SQL preview can scope AdHoc
+      // filters by view and render the "skipped N" hint reactively (issue #307).
+      expect(datasource.getMetadata).toHaveBeenCalled();
     });
 
     it('should show JSON viewer with query content when unsupported features detected', async () => {

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -35,10 +35,15 @@ function useCubeQueryJson(query: CubeQuery, datasource: DataSource): BuiltCubeQu
   const fromTime = templateSrv.replace('$__from', {});
   const toTime = templateSrv.replace('$__to', {});
 
+  // Subscribe to metadata so the AdHoc view-scoping (and the "skipped N" hint)
+  // re-renders once metadata loads, in BOTH the visual and unsupported/JSON
+  // editor modes (issue #307). react-query dedupes the fetch.
+  const { data: metadata } = useMetadataQuery({ datasource });
+
   return useMemo(
-    () => buildCubeQueryJson(query, datasource),
+    () => buildCubeQueryJson(query, datasource, metadata),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [query, datasource, adHocFiltersKey, cubeTimeDimension, fromTime, toTime]
+    [query, datasource, adHocFiltersKey, cubeTimeDimension, fromTime, toTime, metadata]
   );
 }
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -10,7 +10,7 @@ import { useMetadataQuery, useCompiledSqlQuery, MetadataOption } from '../querie
 import { OrderBy } from './OrderBy/OrderBy';
 import { FilterField } from './FilterField/FilterField';
 import { useQueryEditorHandlers } from '../hooks/useQueryEditorHandlers';
-import { buildCubeQueryJson } from '../utils/buildCubeQuery';
+import { buildCubeQueryJson, BuiltCubeQuery } from '../utils/buildCubeQuery';
 import { detectUnsupportedFeatures } from '../utils/detectUnsupportedFeatures';
 import { decorateWithViewSelection, getViewSelectionState } from '../utils/viewSelection';
 import { JsonQueryViewer } from './JsonQueryViewer';
@@ -25,7 +25,7 @@ type Props = QueryEditorProps<DataSource, CubeQuery, CubeDataSourceOptions>;
  * Without surfacing these as useMemo dependencies, the SQL preview goes stale
  * when dashboard-level values change. See grafana/semantic-layer#13.
  */
-function useCubeQueryJson(query: CubeQuery, datasource: DataSource): string {
+function useCubeQueryJson(query: CubeQuery, datasource: DataSource): BuiltCubeQuery {
   const templateSrv = getTemplateSrv();
   const withAdHoc = templateSrv as ReturnType<typeof getTemplateSrv> & {
     getAdhocFilters?: (name: string) => unknown[];
@@ -67,7 +67,7 @@ function UnsupportedQueryEditor({
   datasource: DataSource;
   reasons: string[];
 }) {
-  const cubeQueryJson = useCubeQueryJson(query, datasource);
+  const { json: cubeQueryJson, droppedAdHocFilters } = useCubeQueryJson(query, datasource);
   const { data: compiledSql, isLoading: compiledSqlIsLoading } = useCompiledSqlQuery({
     datasource,
     cubeQueryJson,
@@ -86,6 +86,7 @@ function UnsupportedQueryEditor({
       <SQLPreview
         sql={compiledSql?.sql ?? ''}
         exploreSqlDatasourceUid={datasource.instanceSettings?.jsonData?.exploreSqlDatasourceUid}
+        droppedAdHocFilters={droppedAdHocFilters}
       />
     </>
   );
@@ -97,7 +98,7 @@ function UnsupportedQueryEditor({
  */
 function VisualQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   const styles = useStyles2(getStyles);
-  const cubeQueryJson = useCubeQueryJson(query, datasource);
+  const { json: cubeQueryJson, droppedAdHocFilters } = useCubeQueryJson(query, datasource);
 
   const { data, isLoading: metadataIsLoading, isError: metadataIsError } = useMetadataQuery({ datasource });
   const metadata = data ?? { dimensions: [], measures: [] };
@@ -252,6 +253,7 @@ function VisualQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
       <SQLPreview
         sql={compiledSql?.sql ?? ''}
         exploreSqlDatasourceUid={datasource.instanceSettings?.jsonData?.exploreSqlDatasourceUid}
+        droppedAdHocFilters={droppedAdHocFilters}
       />
     </>
   );

--- a/src/components/SQLPreview.test.tsx
+++ b/src/components/SQLPreview.test.tsx
@@ -17,6 +17,7 @@ import { screen } from '@testing-library/react';
 import { setup } from '../testUtils';
 import { SQLPreview } from './SQLPreview';
 import { useDatasourceQuery } from '../queries';
+import { Operator } from '../types';
 
 const mockUseDatasourceQuery = useDatasourceQuery as jest.Mock;
 
@@ -228,6 +229,51 @@ describe('SQLPreview', () => {
 
       const button = screen.queryByRole('link', { name: /Edit SQL in Explore/i });
       expect(button).not.toBeInTheDocument();
+    });
+  });
+
+  describe('skipped AdHoc filters hint (issue #307)', () => {
+    it('shows a "Skipped N" hint listing dropped cross-view filters alongside the SQL', () => {
+      setup(
+        <SQLPreview
+          sql="SELECT * FROM orders"
+          droppedAdHocFilters={[
+            { member: 'view_b.region', operator: Operator.Equals, values: ['uk'] },
+            { member: 'view_c.country', operator: Operator.Equals, values: ['fr'] },
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Skipped 2 inapplicable AdHoc filters')).toBeInTheDocument();
+      expect(screen.getByText(/view_b\.region, view_c\.country/)).toBeInTheDocument();
+    });
+
+    it('uses singular wording for a single dropped filter', () => {
+      setup(
+        <SQLPreview
+          sql="SELECT * FROM orders"
+          droppedAdHocFilters={[{ member: 'view_b.region', operator: Operator.Equals, values: ['uk'] }]}
+        />
+      );
+
+      expect(screen.getByText('Skipped 1 inapplicable AdHoc filter')).toBeInTheDocument();
+    });
+
+    it('renders the hint even when there is no SQL to show', () => {
+      const { container } = setup(
+        <SQLPreview
+          sql=""
+          droppedAdHocFilters={[{ member: 'view_b.region', operator: Operator.Equals, values: ['uk'] }]}
+        />
+      );
+
+      expect(container.firstChild).not.toBeNull();
+      expect(screen.getByText('Skipped 1 inapplicable AdHoc filter')).toBeInTheDocument();
+    });
+
+    it('shows no hint when there are no dropped filters', () => {
+      setup(<SQLPreview sql="SELECT * FROM orders" droppedAdHocFilters={[]} />);
+      expect(screen.queryByText(/Skipped/)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/SQLPreview.tsx
+++ b/src/components/SQLPreview.tsx
@@ -2,24 +2,46 @@ import React from 'react';
 import { css, cx } from '@emotion/css';
 import { EditorFieldGroup, EditorRow } from '@grafana/plugin-ui';
 import { GrafanaTheme2 } from '@grafana/data';
-import { LinkButton, useTheme2 } from '@grafana/ui';
+import { Alert, LinkButton, useTheme2 } from '@grafana/ui';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-sql';
 import { useDatasourceQuery } from '../queries';
+import { CubeFilter } from '../types';
 
 interface SQLPreviewProps {
   sql: string;
   exploreSqlDatasourceUid?: string;
+  /**
+   * AdHoc filters dropped because they target a different Cube view than this
+   * query. Surfaced as a hint so users understand why a dashboard filter did
+   * not apply to this panel (issue #307).
+   */
+  droppedAdHocFilters?: CubeFilter[];
 }
 
-export function SQLPreview({ sql, exploreSqlDatasourceUid }: SQLPreviewProps) {
+export function SQLPreview({ sql, exploreSqlDatasourceUid, droppedAdHocFilters = [] }: SQLPreviewProps) {
   const theme = useTheme2();
   const styles = getStyles(theme);
 
   const { data: targetDatasource, isPending } = useDatasourceQuery(exploreSqlDatasourceUid);
 
+  const droppedHint =
+    droppedAdHocFilters.length > 0 ? (
+      <Alert
+        severity="info"
+        title={`Skipped ${droppedAdHocFilters.length} inapplicable AdHoc filter${
+          droppedAdHocFilters.length === 1 ? '' : 's'
+        }`}
+      >
+        {`These dashboard filters target a different Cube view and were not applied to this panel: ${droppedAdHocFilters
+          .map((f) => f.member)
+          .join(', ')}`}
+      </Alert>
+    ) : null;
+
   if (!sql) {
-    return null;
+    // Still surface the skipped-filters hint even when there is no SQL to show.
+    return droppedHint;
   }
 
   const highlighted = Prism.highlight(sql, Prism.languages.sql, 'sql');
@@ -65,6 +87,7 @@ export function SQLPreview({ sql, exploreSqlDatasourceUid }: SQLPreviewProps) {
   return (
     <EditorRow>
       <EditorFieldGroup>
+        {droppedHint}
         <div className={styles.container}>
           <div
             className={cx(styles.sqlDisplay, 'prism-syntax-highlight')}

--- a/src/components/SQLPreview.tsx
+++ b/src/components/SQLPreview.tsx
@@ -40,8 +40,13 @@ export function SQLPreview({ sql, exploreSqlDatasourceUid, droppedAdHocFilters =
     ) : null;
 
   if (!sql) {
-    // Still surface the skipped-filters hint even when there is no SQL to show.
-    return droppedHint;
+    // Still surface the skipped-filters hint even when there is no SQL to show,
+    // wrapped consistently in the editor row layout.
+    return droppedHint ? (
+      <EditorRow>
+        <EditorFieldGroup>{droppedHint}</EditorFieldGroup>
+      </EditorRow>
+    ) : null;
   }
 
   const highlighted = Prism.highlight(sql, Prism.languages.sql, 'sql');

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -808,6 +808,39 @@ describe('DataSource', () => {
       superSpy.mockRestore();
     });
 
+    it('collapses a cold burst of concurrent queries into a single /v1/meta fetch', async () => {
+      const metadata = { dimensions: [], measures: [] };
+      mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s, getAdhocFilters: () => [] });
+
+      const datasource = createDataSource();
+      (datasource as any).cachedMetadata = null;
+      (datasource as any).metadataInFlight = null;
+
+      let metaCalls = 0;
+      mockGetResource.mockImplementation(async (path: string) => {
+        if (path === 'metadata') {
+          metaCalls++;
+          // Defer so all concurrent callers observe the same in-flight promise.
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return metadata;
+        }
+        return {};
+      });
+      const superSpy = jest.spyOn(superProto, 'query').mockReturnValue(of({ data: [] }));
+
+      // Three panels query concurrently on a cold cache.
+      await Promise.all([
+        lastValueFrom(datasource.query({ targets: [] } as any)),
+        lastValueFrom(datasource.query({ targets: [] } as any)),
+        lastValueFrom(datasource.query({ targets: [] } as any)),
+      ]);
+
+      expect(metaCalls).toBe(1);
+      expect(superSpy).toHaveBeenCalledTimes(3);
+
+      superSpy.mockRestore();
+    });
+
     it('still runs the query (inject-all fallback) when metadata fetch fails on cold start', async () => {
       const datasource = createDataSource();
       (datasource as any).cachedMetadata = null;

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -2,6 +2,7 @@ import { DataSource } from './datasource';
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { CubeDataSourceOptions, CubeFilter, CubeQuery, Operator } from './types';
 import { getTemplateSrv } from '@grafana/runtime';
+import { of, lastValueFrom } from 'rxjs';
 
 // Mock @grafana/runtime
 jest.mock('@grafana/runtime', () => ({
@@ -753,6 +754,78 @@ describe('DataSource', () => {
 
       const query = { refId: 'A', measures: ['orders.count'] };
       expect(datasource.filterQuery(query)).toBe(true);
+    });
+  });
+
+  describe('query() metadata gating (issue #307 cold-start)', () => {
+    const superProto = Object.getPrototypeOf(DataSource.prototype);
+
+    it('awaits metadata BEFORE running the first query when the cache is cold', async () => {
+      const metadata = {
+        dimensions: [{ label: 'orders.status', value: 'orders.status', type: 'string', cube: 'orders' }],
+        measures: [],
+      };
+      mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s, getAdhocFilters: () => [] });
+
+      const datasource = createDataSource();
+      // Force a cold cache (ignore any best-effort constructor prefetch).
+      (datasource as any).cachedMetadata = null;
+
+      const order: string[] = [];
+      mockGetResource.mockImplementation(async (path: string) => {
+        if (path === 'metadata') {
+          order.push('metadata');
+          return metadata;
+        }
+        return {};
+      });
+      const superSpy = jest.spyOn(superProto, 'query').mockImplementation(() => {
+        order.push('query');
+        return of({ data: [] });
+      });
+
+      await lastValueFrom(datasource.query({ targets: [] } as any));
+
+      // Metadata is fetched first, THEN the backend query runs -> no cold race.
+      expect(order).toEqual(['metadata', 'query']);
+      expect((datasource as any).cachedMetadata).toEqual(metadata);
+
+      superSpy.mockRestore();
+    });
+
+    it('does NOT re-fetch metadata when the cache is already warm', async () => {
+      const datasource = createDataSource();
+      (datasource as any).cachedMetadata = { dimensions: [], measures: [] };
+
+      mockGetResource.mockClear();
+      const superSpy = jest.spyOn(superProto, 'query').mockReturnValue(of({ data: [] }));
+
+      await lastValueFrom(datasource.query({ targets: [] } as any));
+
+      expect(superSpy).toHaveBeenCalledTimes(1);
+      expect(mockGetResource).not.toHaveBeenCalledWith('metadata');
+
+      superSpy.mockRestore();
+    });
+
+    it('still runs the query (inject-all fallback) when metadata fetch fails on cold start', async () => {
+      const datasource = createDataSource();
+      (datasource as any).cachedMetadata = null;
+
+      mockGetResource.mockImplementation(async (path: string) => {
+        if (path === 'metadata') {
+          throw new Error('metadata unavailable');
+        }
+        return {};
+      });
+      const superSpy = jest.spyOn(superProto, 'query').mockReturnValue(of({ data: [] }));
+
+      await lastValueFrom(datasource.query({ targets: [] } as any));
+
+      expect(superSpy).toHaveBeenCalledTimes(1);
+      expect((datasource as any).cachedMetadata).toBeNull();
+
+      superSpy.mockRestore();
     });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -3,13 +3,26 @@ import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
 import { CubeQuery, CubeDataSourceOptions, DEFAULT_QUERY, Operator } from './types';
 import { normalizeCubeQuery } from './utils/normalizeCubeQuery';
+import type { MetadataResponse } from './queries';
 
 export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceOptions> {
   readonly instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions>;
 
+  // Cached view metadata (member -> view) so the synchronous runtime path
+  // (applyTemplateVariables) can drop cross-view AdHoc filters (issue #307).
+  private cachedMetadata: MetadataResponse | null = null;
+
   constructor(instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions>) {
     super(instanceSettings);
     this.instanceSettings = instanceSettings;
+    // Warm the metadata cache so the first dashboard queries can already scope
+    // AdHoc filters by view. Best-effort: failures fall back to prior behavior.
+    void this.getMetadata().catch(() => {});
+  }
+
+  /** Synchronously exposes the cached view metadata, or null before it loads. */
+  getCachedMetadata(): MetadataResponse | null {
+    return this.cachedMetadata;
   }
 
   getDefaultQuery(_: CoreApp): Partial<CubeQuery> {
@@ -22,6 +35,8 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
       datasourceName: this.name,
       mapOperator: (operator) => this.mapOperator(operator),
       scopedVars,
+      // Drop AdHoc filters that belong to a different Cube view (issue #307).
+      metadata: this.cachedMetadata ?? undefined,
     });
 
     return {
@@ -121,8 +136,11 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
     return [{ dimension, dateRange: [from, to] }];
   }
 
-  // Get available dimensions and measures for the query builder
-  getMetadata() {
-    return this.getResource('metadata');
+  // Get available dimensions and measures for the query builder.
+  // Caches the result so the runtime path can scope AdHoc filters by view (#307).
+  async getMetadata(): Promise<MetadataResponse> {
+    const metadata = await this.getResource<MetadataResponse>('metadata');
+    this.cachedMetadata = metadata;
+    return metadata;
   }
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,5 +1,7 @@
-import { DataSourceInstanceSettings, CoreApp, ScopedVars, TimeRange } from '@grafana/data';
+import { DataSourceInstanceSettings, CoreApp, ScopedVars, TimeRange, DataQueryRequest, DataQueryResponse } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
+import { Observable, from } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 
 import { CubeQuery, CubeDataSourceOptions, DEFAULT_QUERY, Operator } from './types';
 import { normalizeCubeQuery } from './utils/normalizeCubeQuery';
@@ -15,14 +17,28 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
   constructor(instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions>) {
     super(instanceSettings);
     this.instanceSettings = instanceSettings;
-    // Warm the metadata cache so the first dashboard queries can already scope
-    // AdHoc filters by view. Best-effort: failures fall back to prior behavior.
-    void this.getMetadata().catch(() => {});
+    // Note: we intentionally do NOT prefetch metadata here. The async query()
+    // path loads-and-caches it before the first query runs (issue #307), which
+    // avoids firing a metadata request in non-query contexts (config editor /
+    // health checks).
   }
 
   /** Synchronously exposes the cached view metadata, or null before it loads. */
   getCachedMetadata(): MetadataResponse | null {
     return this.cachedMetadata;
+  }
+
+  // Ensure the view metadata is loaded BEFORE any query is executed, so the very
+  // first runtime query on a fresh dashboard can already scope AdHoc filters by
+  // view (issue #307). applyTemplateVariables is synchronous and cannot await, so
+  // we gate here in the async query() path; without this a cold-start dashboard
+  // could inject cross-view filters and leave panels red until a manual refresh.
+  query(request: DataQueryRequest<CubeQuery>): Observable<DataQueryResponse> {
+    if (this.cachedMetadata) {
+      return super.query(request);
+    }
+    // Best-effort: on failure, fall back to prior inject-all behavior.
+    return from(this.getMetadata().catch(() => null)).pipe(mergeMap(() => super.query(request)));
   }
 
   getDefaultQuery(_: CoreApp): Partial<CubeQuery> {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -13,6 +13,9 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
   // Cached view metadata (member -> view) so the synchronous runtime path
   // (applyTemplateVariables) can drop cross-view AdHoc filters (issue #307).
   private cachedMetadata: MetadataResponse | null = null;
+  // Shared in-flight metadata fetch so a cold dashboard's concurrent per-panel
+  // query() calls collapse to a SINGLE /v1/meta request instead of N (issue #307).
+  private metadataInFlight: Promise<MetadataResponse> | null = null;
 
   constructor(instanceSettings: DataSourceInstanceSettings<CubeDataSourceOptions>) {
     super(instanceSettings);
@@ -153,10 +156,20 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
   }
 
   // Get available dimensions and measures for the query builder.
-  // Caches the result so the runtime path can scope AdHoc filters by view (#307).
-  async getMetadata(): Promise<MetadataResponse> {
-    const metadata = await this.getResource<MetadataResponse>('metadata');
-    this.cachedMetadata = metadata;
-    return metadata;
+  // Caches the result so the runtime path can scope AdHoc filters by view (#307),
+  // and de-dupes concurrent fetches (a cold burst of panel queries shares one).
+  getMetadata(): Promise<MetadataResponse> {
+    if (this.metadataInFlight) {
+      return this.metadataInFlight;
+    }
+    this.metadataInFlight = this.getResource<MetadataResponse>('metadata')
+      .then((metadata) => {
+        this.cachedMetadata = metadata;
+        return metadata;
+      })
+      .finally(() => {
+        this.metadataInFlight = null;
+      });
+    return this.metadataInFlight;
   }
 }

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -41,19 +41,22 @@ export const createMockDataSource = (mockMetadata: any = null, mockSQLResponse: 
 
   const datasource = new DataSource(instanceSettings);
 
-  // Mock getMetadata
-  datasource.getMetadata = jest.fn().mockResolvedValue(
-    mockMetadata || {
-      dimensions: [
-        { label: 'orders.status', value: 'orders.status' },
-        { label: 'orders.customer', value: 'orders.customer' },
-      ],
-      measures: [
-        { label: 'orders.count', value: 'orders.count' },
-        { label: 'orders.total', value: 'orders.total' },
-      ],
-    }
-  );
+  // Mock getMetadata. Members carry `cube` (their Cube view) so AdHoc view-scoping
+  // (issue #307) can infer this single "orders" view and keep orders.* filters.
+  const metadata = mockMetadata || {
+    dimensions: [
+      { label: 'orders.status', value: 'orders.status', type: 'string', cube: 'orders' },
+      { label: 'orders.customer', value: 'orders.customer', type: 'string', cube: 'orders' },
+      { label: 'orders.region', value: 'orders.region', type: 'string', cube: 'orders' },
+    ],
+    measures: [
+      { label: 'orders.count', value: 'orders.count', type: 'number', cube: 'orders' },
+      { label: 'orders.total', value: 'orders.total', type: 'number', cube: 'orders' },
+    ],
+  };
+  datasource.getMetadata = jest.fn().mockResolvedValue(metadata);
+  // Synchronous cache accessor used by the runtime path / buildCubeQueryJson fallback.
+  datasource.getCachedMetadata = jest.fn().mockReturnValue(metadata);
 
   // Mock getResource for SQL compilation
   datasource.getResource = jest.fn().mockResolvedValue(

--- a/src/utils/buildCubeQuery.test.ts
+++ b/src/utils/buildCubeQuery.test.ts
@@ -162,4 +162,27 @@ describe('buildCubeQueryJson', () => {
     // ...and the cross-view filter is reported as dropped.
     expect(droppedAdHocFilters).toEqual([{ member: 'view_b.region', operator: 'equals', values: ['fr'] }]);
   });
+
+  it('does NOT report dropped filters for an incomplete (no-view) query (issue #307 review)', () => {
+    mockGetTemplateSrv.mockReturnValue({
+      replace: (value: string) => value,
+      getAdhocFilters: () => [{ key: 'view_a.region', operator: '=', value: 'uk' }],
+    });
+
+    const datasource = createDatasourceStub();
+    datasource.getCachedMetadata = jest.fn(() => ({
+      dimensions: [{ label: 'view_a.region', value: 'view_a.region', type: 'string', cube: 'view_a' }],
+      measures: [{ label: 'view_a.count', value: 'view_a.count', type: 'number', cube: 'view_a' }],
+    }));
+
+    // Empty query: no dimensions/measures/filters -> no view can be inferred.
+    const query: CubeQuery = { refId: 'A' };
+
+    const { json, droppedAdHocFilters } = buildCubeQueryJson(query, datasource);
+
+    // No SQL to build, and crucially NO dropped filters reported (they will
+    // apply once a dimension/measure is chosen) -> no misleading hint.
+    expect(json).toBe('');
+    expect(droppedAdHocFilters).toEqual([]);
+  });
 });

--- a/src/utils/buildCubeQuery.test.ts
+++ b/src/utils/buildCubeQuery.test.ts
@@ -18,6 +18,8 @@ const createDatasourceStub = () => {
       }
       return Operator.Equals;
     }),
+    // No cached view metadata in these tests -> AdHoc view-scoping is a no-op (#307).
+    getCachedMetadata: jest.fn(() => null),
   } as any;
 };
 
@@ -37,7 +39,7 @@ describe('buildCubeQueryJson', () => {
       limit: 0,
     };
 
-    const result = JSON.parse(buildCubeQueryJson(query, datasource));
+    const result = JSON.parse(buildCubeQueryJson(query, datasource).json);
 
     expect(result.limit).toBe(0);
   });
@@ -49,7 +51,7 @@ describe('buildCubeQueryJson', () => {
       measures: ['orders.count'],
     };
 
-    const result = JSON.parse(buildCubeQueryJson(query, datasource));
+    const result = JSON.parse(buildCubeQueryJson(query, datasource).json);
 
     expect(result).not.toHaveProperty('limit');
   });
@@ -62,7 +64,7 @@ describe('buildCubeQueryJson', () => {
       filters: [{ member: 'orders.discount', operator: Operator.Set }],
     };
 
-    const result = JSON.parse(buildCubeQueryJson(query, datasource));
+    const result = JSON.parse(buildCubeQueryJson(query, datasource).json);
 
     expect(result.filters).toEqual([{ member: 'orders.discount', operator: 'set' }]);
   });
@@ -87,7 +89,7 @@ describe('buildCubeQueryJson', () => {
       ],
     };
 
-    const result = JSON.parse(buildCubeQueryJson(query, datasource));
+    const result = JSON.parse(buildCubeQueryJson(query, datasource).json);
 
     expect(result.filters).toEqual([
       {
@@ -127,8 +129,37 @@ describe('buildCubeQueryJson', () => {
       measures: ['orders.count'],
     };
 
-    const result = JSON.parse(buildCubeQueryJson(query, datasource));
+    const result = JSON.parse(buildCubeQueryJson(query, datasource).json);
 
     expect(result).not.toHaveProperty('timeDimensions');
+  });
+
+  it('surfaces AdHoc filters dropped as inapplicable to the query view (issue #307)', () => {
+    mockGetTemplateSrv.mockReturnValue({
+      replace: (value: string) => value,
+      getAdhocFilters: () => [
+        { key: 'view_a.region', operator: '=', value: 'uk' },
+        { key: 'view_b.region', operator: '=', value: 'fr' },
+      ],
+    });
+
+    const datasource = createDatasourceStub();
+    datasource.getCachedMetadata = jest.fn(() => ({
+      dimensions: [
+        { label: 'view_a.region', value: 'view_a.region', type: 'string', cube: 'view_a' },
+        { label: 'view_b.region', value: 'view_b.region', type: 'string', cube: 'view_b' },
+      ],
+      measures: [{ label: 'view_a.count', value: 'view_a.count', type: 'number', cube: 'view_a' }],
+    }));
+
+    const query: CubeQuery = { refId: 'A', measures: ['view_a.count'] };
+
+    const { json, droppedAdHocFilters } = buildCubeQueryJson(query, datasource);
+    const parsed = JSON.parse(json);
+
+    // Only the same-view filter is applied...
+    expect(parsed.filters).toEqual([{ member: 'view_a.region', operator: 'equals', values: ['uk'] }]);
+    // ...and the cross-view filter is reported as dropped.
+    expect(droppedAdHocFilters).toEqual([{ member: 'view_b.region', operator: 'equals', values: ['fr'] }]);
   });
 });

--- a/src/utils/buildCubeQuery.ts
+++ b/src/utils/buildCubeQuery.ts
@@ -1,7 +1,14 @@
 import type { BinaryFilter, UnaryFilter, Filter as CubeJsFilter, Query as CubeJsQuery } from '@cubejs-client/core';
 import { DataSource } from '../datasource';
-import { CubeFilterItem, CubeQuery, UNARY_OPERATORS, isCubeFilter, isCubeAndFilter, isCubeOrFilter } from '../types';
+import { CubeFilter, CubeFilterItem, CubeQuery, UNARY_OPERATORS, isCubeFilter, isCubeAndFilter, isCubeOrFilter } from '../types';
 import { normalizeCubeQuery } from './normalizeCubeQuery';
+
+export interface BuiltCubeQuery {
+  /** The Cube query JSON, or '' when the query has no dimensions/measures. */
+  json: string;
+  /** AdHoc filters dropped because they target a different view (issue #307). */
+  droppedAdHocFilters: CubeFilter[];
+}
 
 /**
  * Builds a Cube.js query JSON string from a Grafana query object.
@@ -9,15 +16,21 @@ import { normalizeCubeQuery } from './normalizeCubeQuery';
  *
  * This function uses @cubejs-client/core types to ensure compile-time
  * compatibility with Cube's /load endpoint format.
+ *
+ * Also returns the AdHoc filters that were dropped as inapplicable to this
+ * query's view, so the SQL preview can explain why they did not apply (#307).
  */
-export function buildCubeQueryJson(query: CubeQuery, datasource: DataSource): string {
+export function buildCubeQueryJson(query: CubeQuery, datasource: DataSource): BuiltCubeQuery {
   const normalizedQuery = normalizeCubeQuery(query, {
     datasourceName: datasource.name,
     mapOperator: (operator) => datasource.mapOperator(operator),
+    metadata: datasource.getCachedMetadata() ?? undefined,
   });
 
+  const droppedAdHocFilters = normalizedQuery.droppedAdHocFilters ?? [];
+
   if (!normalizedQuery.dimensions?.length && !normalizedQuery.measures?.length) {
-    return '';
+    return { json: '', droppedAdHocFilters };
   }
 
   // Using CubeJsQuery type for compile-time checking against Cube's official API
@@ -47,7 +60,7 @@ export function buildCubeQueryJson(query: CubeQuery, datasource: DataSource): st
     cubeQuery.limit = normalizedQuery.limit;
   }
 
-  return JSON.stringify(cubeQuery);
+  return { json: JSON.stringify(cubeQuery), droppedAdHocFilters };
 }
 
 /**

--- a/src/utils/buildCubeQuery.ts
+++ b/src/utils/buildCubeQuery.ts
@@ -2,6 +2,7 @@ import type { BinaryFilter, UnaryFilter, Filter as CubeJsFilter, Query as CubeJs
 import { DataSource } from '../datasource';
 import { CubeFilter, CubeFilterItem, CubeQuery, UNARY_OPERATORS, isCubeFilter, isCubeAndFilter, isCubeOrFilter } from '../types';
 import { normalizeCubeQuery } from './normalizeCubeQuery';
+import type { ViewSelectionMetadata } from './viewSelection';
 
 export interface BuiltCubeQuery {
   /** The Cube query JSON, or '' when the query has no dimensions/measures. */
@@ -20,11 +21,18 @@ export interface BuiltCubeQuery {
  * Also returns the AdHoc filters that were dropped as inapplicable to this
  * query's view, so the SQL preview can explain why they did not apply (#307).
  */
-export function buildCubeQueryJson(query: CubeQuery, datasource: DataSource): BuiltCubeQuery {
+export function buildCubeQueryJson(
+  query: CubeQuery,
+  datasource: DataSource,
+  // Optional explicit view metadata. Callers (e.g. the SQL preview) pass the
+  // reactive useMetadataQuery result so the "skipped N" hint updates when
+  // metadata loads; falls back to the datasource cache otherwise (issue #307).
+  metadata?: ViewSelectionMetadata
+): BuiltCubeQuery {
   const normalizedQuery = normalizeCubeQuery(query, {
     datasourceName: datasource.name,
     mapOperator: (operator) => datasource.mapOperator(operator),
-    metadata: datasource.getCachedMetadata() ?? undefined,
+    metadata: metadata ?? datasource.getCachedMetadata() ?? undefined,
   });
 
   const droppedAdHocFilters = normalizedQuery.droppedAdHocFilters ?? [];

--- a/src/utils/normalizeCubeQuery.test.ts
+++ b/src/utils/normalizeCubeQuery.test.ts
@@ -148,3 +148,140 @@ describe('normalizeCubeQuery timeDimensions intersection (issue #173)', () => {
     expect(result.timeDimensions).toBeUndefined();
   });
 });
+
+describe('normalizeCubeQuery AdHoc view-scoping (issue #307)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Metadata with two sealed views, each fully-qualifying its own members.
+  const metadata = {
+    dimensions: [
+      { label: 'view_a.region', value: 'view_a.region', type: 'string', cube: 'view_a' },
+      { label: 'view_a.customer', value: 'view_a.customer', type: 'string', cube: 'view_a' },
+      { label: 'view_b.region', value: 'view_b.region', type: 'string', cube: 'view_b' },
+    ],
+    measures: [
+      { label: 'view_a.count', value: 'view_a.count', type: 'number', cube: 'view_a' },
+      { label: 'view_b.count', value: 'view_b.count', type: 'number', cube: 'view_b' },
+    ],
+  };
+
+  const withAdHocFilters = (filters: Array<{ key: string; operator: string; value: string; values?: string[] }>) =>
+    mockGetTemplateSrv.mockReturnValue({
+      getAdhocFilters: () => filters,
+      // No $cubeTimeDimension / range unless a test overrides it.
+      replace: (str: string) => str,
+    });
+
+  const options = { ...baseOptions, metadata };
+
+  it('keeps an AdHoc filter whose member belongs to the query view', () => {
+    withAdHocFilters([{ key: 'view_a.region', operator: '=', value: 'uk' }]);
+    const query = { refId: 'A', dimensions: ['view_a.customer'], measures: ['view_a.count'] } as CubeQuery;
+
+    const result = normalizeCubeQuery(query, options);
+
+    expect(result.filters).toEqual([{ member: 'view_a.region', operator: Operator.Equals, values: ['uk'] }]);
+    expect(result.droppedAdHocFilters).toBeUndefined();
+  });
+
+  it('drops an AdHoc filter whose member belongs to a different view', () => {
+    withAdHocFilters([{ key: 'view_b.region', operator: '=', value: 'uk' }]);
+    const query = { refId: 'A', dimensions: ['view_a.customer'], measures: ['view_a.count'] } as CubeQuery;
+
+    const result = normalizeCubeQuery(query, options);
+
+    expect(result.filters).toBeUndefined();
+    expect(result.droppedAdHocFilters).toEqual([{ member: 'view_b.region', operator: Operator.Equals, values: ['uk'] }]);
+  });
+
+  it('keeps matching and drops non-matching filters together (mixed multi-view)', () => {
+    withAdHocFilters([
+      { key: 'view_a.region', operator: '=', value: 'uk' },
+      { key: 'view_b.region', operator: '=', value: 'fr' },
+    ]);
+    const query = { refId: 'A', measures: ['view_a.count'] } as CubeQuery;
+
+    const result = normalizeCubeQuery(query, options);
+
+    expect(result.filters).toEqual([{ member: 'view_a.region', operator: Operator.Equals, values: ['uk'] }]);
+    expect(result.droppedAdHocFilters).toEqual([{ member: 'view_b.region', operator: Operator.Equals, values: ['fr'] }]);
+  });
+
+  it('infers the query view from panel filters when no dims/measures are set', () => {
+    withAdHocFilters([{ key: 'view_a.region', operator: '=', value: 'uk' }]);
+    const query = {
+      refId: 'A',
+      filters: [{ member: 'view_a.customer', operator: Operator.Equals, values: ['BBC'] }],
+    } as unknown as CubeQuery;
+
+    const result = normalizeCubeQuery(query, options);
+
+    // view inferred as view_a from the panel filter -> AdHoc kept.
+    expect(result.droppedAdHocFilters).toBeUndefined();
+    expect(result.filters).toEqual(
+      expect.arrayContaining([{ member: 'view_a.region', operator: Operator.Equals, values: ['uk'] }])
+    );
+  });
+
+  it('drops ALL AdHoc filters when no view can be inferred (empty query)', () => {
+    withAdHocFilters([{ key: 'view_a.region', operator: '=', value: 'uk' }]);
+    const query = { refId: 'A' } as CubeQuery;
+
+    const result = normalizeCubeQuery(query, options);
+
+    expect(result.filters).toBeUndefined();
+    expect(result.droppedAdHocFilters).toEqual([{ member: 'view_a.region', operator: Operator.Equals, values: ['uk'] }]);
+  });
+
+  it('drops an AdHoc filter whose member is not present in metadata (unknown view)', () => {
+    withAdHocFilters([{ key: 'orders.unknown', operator: '=', value: 'x' }]);
+    const query = { refId: 'A', measures: ['view_a.count'] } as CubeQuery;
+
+    const result = normalizeCubeQuery(query, options);
+
+    expect(result.filters).toBeUndefined();
+    expect(result.droppedAdHocFilters).toEqual([{ member: 'orders.unknown', operator: Operator.Equals, values: ['x'] }]);
+  });
+
+  it('keeps ALL AdHoc filters (prior behavior) when metadata is not provided', () => {
+    withAdHocFilters([{ key: 'view_b.region', operator: '=', value: 'uk' }]);
+    const query = { refId: 'A', measures: ['view_a.count'] } as CubeQuery;
+
+    // baseOptions has no metadata -> no view scoping, inject everything.
+    const result = normalizeCubeQuery(query, baseOptions);
+
+    expect(result.filters).toEqual([{ member: 'view_b.region', operator: Operator.Equals, values: ['uk'] }]);
+    expect(result.droppedAdHocFilters).toBeUndefined();
+  });
+
+  it('still injects the dashboard time dimension while dropping a cross-view AdHoc filter (interaction with #35/#173)', () => {
+    mockGetTemplateSrv.mockReturnValue({
+      getAdhocFilters: () => [{ key: 'view_b.region', operator: '=', value: 'uk' }],
+      replace: (str: string) => {
+        if (str === '$cubeTimeDimension') {
+          return 'view_a.order_date';
+        }
+        if (str === '$__from') {
+          return DASH_FROM;
+        }
+        if (str === '$__to') {
+          return DASH_TO;
+        }
+        return str;
+      },
+    });
+    const query = { refId: 'A', measures: ['view_a.count'] } as CubeQuery;
+
+    const result = normalizeCubeQuery(query, options);
+
+    // Cross-view AdHoc dropped...
+    expect(result.filters).toBeUndefined();
+    expect(result.droppedAdHocFilters).toEqual([{ member: 'view_b.region', operator: Operator.Equals, values: ['uk'] }]);
+    // ...but the dashboard time-range injection is unaffected.
+    expect(result.timeDimensions).toEqual([
+      { dimension: 'view_a.order_date', dateRange: [DASH_FROM_ISO, DASH_TO_ISO] },
+    ]);
+  });
+});

--- a/src/utils/normalizeCubeQuery.test.ts
+++ b/src/utils/normalizeCubeQuery.test.ts
@@ -225,14 +225,17 @@ describe('normalizeCubeQuery AdHoc view-scoping (issue #307)', () => {
     );
   });
 
-  it('drops ALL AdHoc filters when no view can be inferred (empty query)', () => {
+  it('skips AdHoc injection WITHOUT flagging drops when no view can be inferred (empty query)', () => {
     withAdHocFilters([{ key: 'view_a.region', operator: '=', value: 'uk' }]);
     const query = { refId: 'A' } as CubeQuery;
 
     const result = normalizeCubeQuery(query, options);
 
+    // Filters are not injected (view unknown), but they are NOT reported as
+    // dropped/inapplicable: they will apply once a dimension/measure is added,
+    // so the SQL preview must not show a misleading "different view" hint (#307).
     expect(result.filters).toBeUndefined();
-    expect(result.droppedAdHocFilters).toEqual([{ member: 'view_a.region', operator: Operator.Equals, values: ['uk'] }]);
+    expect(result.droppedAdHocFilters).toBeUndefined();
   });
 
   it('drops an AdHoc filter whose member is not present in metadata (unknown view)', () => {

--- a/src/utils/normalizeCubeQuery.ts
+++ b/src/utils/normalizeCubeQuery.ts
@@ -4,6 +4,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { CubeFilter, CubeFilterItem, CubeQuery, Operator, UNARY_OPERATORS, isCubeAndFilter, isCubeFilter, isCubeOrFilter } from '../types';
 import { filterValidCubeFilters } from './filterValidation';
 import { normalizeOrder, OrderArray } from './normalizeOrder';
+import { buildMemberViewMap, getViewSelectionState, ViewSelectionMetadata } from './viewSelection';
 
 interface AdHocFilter {
   key: string;
@@ -16,6 +17,12 @@ interface NormalizeCubeQueryOptions {
   datasourceName: string;
   mapOperator: (grafanaOperator: string) => Operator;
   scopedVars?: ScopedVars;
+  /**
+   * View metadata (dimensions/measures with their `cube`/view) used to drop
+   * AdHoc filters that target a different Cube view than this query (issue #307).
+   * When omitted (e.g. before metadata has loaded), AdHoc injection is unchanged.
+   */
+  metadata?: ViewSelectionMetadata;
 }
 
 export interface NormalizedCubeQuery {
@@ -25,6 +32,12 @@ export interface NormalizedCubeQuery {
   filters?: CubeFilterItem[];
   order?: OrderArray;
   limit?: number;
+  /**
+   * AdHoc filters that were dropped because they target a different view than
+   * this query (or no view could be inferred). Surfaced in the SQL preview so
+   * users understand why a dashboard filter did not apply (issue #307).
+   */
+  droppedAdHocFilters?: CubeFilter[];
 }
 
 /**
@@ -46,7 +59,17 @@ export function normalizeCubeQuery(query: CubeQuery, options: NormalizeCubeQuery
     values: filter.values && filter.values.length > 0 ? filter.values : [filter.value],
   }));
 
-  const validFilters = filterValidCubeFilters([...interpolatedFilters, ...adHocFilters]).map(stripUnaryFilterValues);
+  // Cube views are sealed namespaces (members are fully qualified, e.g. `view_a.region`).
+  // Injecting an AdHoc filter for a member of a different view makes Cube /v1/load
+  // error and turns unrelated panels red. Drop AdHoc filters whose member does not
+  // belong to this query's inferred view (issue #307).
+  const { applicable: applicableAdHocFilters, dropped: droppedAdHocFilters } = partitionAdHocFiltersByView(
+    adHocFilters,
+    query,
+    options.metadata
+  );
+
+  const validFilters = filterValidCubeFilters([...interpolatedFilters, ...applicableAdHocFilters]).map(stripUnaryFilterValues);
 
   const queryTimeDimensions = interpolateTimeDimensions(query.timeDimensions, templateSrv, scopedVars) ?? [];
   const timeDimensions = applyDashboardTimeRange(queryTimeDimensions, templateSrv, scopedVars);
@@ -58,7 +81,51 @@ export function normalizeCubeQuery(query: CubeQuery, options: NormalizeCubeQuery
     filters: validFilters.length > 0 ? validFilters : undefined,
     order: normalizeOrder(query.order),
     limit: query.limit ?? undefined,
+    droppedAdHocFilters: droppedAdHocFilters.length > 0 ? droppedAdHocFilters : undefined,
   };
+}
+
+/**
+ * Split injected AdHoc filters into those applicable to this query's view and
+ * those that must be dropped (they target a different view), reusing the same
+ * view-inference logic as the query builder's getViewSelectionState.
+ *
+ * - No metadata (not loaded yet): keep ALL AdHoc filters (prior behavior), so
+ *   single-view dashboards are not regressed before metadata resolves.
+ * - Metadata present but no view inferable (empty query / no dims/measures/
+ *   panel-filters): skip AdHoc injection entirely (all dropped).
+ * - Otherwise: keep filters whose member's view matches the query's view.
+ *   Members not present in metadata are treated as non-matching and dropped.
+ */
+function partitionAdHocFiltersByView(
+  adHocFilters: CubeFilter[],
+  query: CubeQuery,
+  metadata?: ViewSelectionMetadata
+): { applicable: CubeFilter[]; dropped: CubeFilter[] } {
+  if (!metadata) {
+    return { applicable: adHocFilters, dropped: [] };
+  }
+
+  const { view } = getViewSelectionState(
+    { dimensions: query.dimensions, measures: query.measures, filters: query.filters },
+    metadata
+  );
+
+  if (!view) {
+    return { applicable: [], dropped: adHocFilters };
+  }
+
+  const memberToView = buildMemberViewMap(metadata);
+  const applicable: CubeFilter[] = [];
+  const dropped: CubeFilter[] = [];
+  for (const filter of adHocFilters) {
+    if (memberToView.get(filter.member) === view) {
+      applicable.push(filter);
+    } else {
+      dropped.push(filter);
+    }
+  }
+  return { applicable, dropped };
 }
 
 function interpolateFilterItem(

--- a/src/utils/normalizeCubeQuery.ts
+++ b/src/utils/normalizeCubeQuery.ts
@@ -112,7 +112,13 @@ function partitionAdHocFiltersByView(
   );
 
   if (!view) {
-    return { applicable: [], dropped: adHocFilters };
+    // No view can be inferred yet (empty/incomplete query with no dims/measures/
+    // panel-filters). We still can't safely inject AdHoc filters (we don't know
+    // which view they'd target), but these are NOT "inapplicable / wrong-view"
+    // drops — they will apply once the user picks a dimension/measure. So we do
+    // NOT report them as dropped, avoiding a misleading "targets a different
+    // Cube view" hint on a fresh panel (issue #307 review).
+    return { applicable: [], dropped: [] };
   }
 
   const memberToView = buildMemberViewMap(metadata);

--- a/src/utils/viewSelection.test.ts
+++ b/src/utils/viewSelection.test.ts
@@ -1,5 +1,5 @@
 import { MetadataOption } from '../queries';
-import { decorateWithViewSelection, getViewSelectionState } from './viewSelection';
+import { buildMemberViewMap, decorateWithViewSelection, getViewSelectionState } from './viewSelection';
 
 const opt = (value: string, view = value.split('.')[0], extra: Partial<MetadataOption> = {}): MetadataOption => ({
   label: value,
@@ -100,5 +100,25 @@ describe('decorateWithViewSelection', () => {
       existing: true,
       originalDescription: 'attribution channel',
     });
+  });
+});
+
+describe('buildMemberViewMap (issue #307)', () => {
+  it('maps every dimension and measure member to its view', () => {
+    const map = buildMemberViewMap({
+      dimensions: [opt('view_a.region'), opt('view_b.region')],
+      measures: [opt('view_a.count'), opt('view_b.count')],
+    });
+
+    expect(map.get('view_a.region')).toBe('view_a');
+    expect(map.get('view_b.region')).toBe('view_b');
+    expect(map.get('view_a.count')).toBe('view_a');
+    expect(map.get('view_b.count')).toBe('view_b');
+    expect(map.get('unknown.member')).toBeUndefined();
+    expect(map.size).toBe(4);
+  });
+
+  it('returns an empty map for empty metadata', () => {
+    expect(buildMemberViewMap({ dimensions: [], measures: [] }).size).toBe(0);
   });
 });

--- a/src/utils/viewSelection.ts
+++ b/src/utils/viewSelection.ts
@@ -8,9 +8,22 @@ interface ViewSelectionQuery {
   filters?: unknown[];
 }
 
-interface ViewSelectionMetadata {
+export interface ViewSelectionMetadata {
   dimensions: MetadataOption[];
   measures: MetadataOption[];
+}
+
+/**
+ * Build a member (fully-qualified name) -> view (cube) map from metadata.
+ * Cube view members are fully qualified (e.g. `view_a.region`), so this lets us
+ * tell which view an AdHoc filter's key belongs to. See issue #307.
+ */
+export function buildMemberViewMap(metadata: ViewSelectionMetadata): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const option of [...metadata.dimensions, ...metadata.measures]) {
+    map.set(option.value, option.cube);
+  }
+  return map;
 }
 
 export interface ViewSelectionState {


### PR DESCRIPTION
Fixes #307. Implements **Option 1** ("Drop inapplicable filters at injection time — ship now") from the issue.

## Problem

Dashboard AdHoc filters were injected into **every** Cube query regardless of view. Cube views are sealed namespaces (members are fully qualified, e.g. `view_a.region`), so applying a `view_a.region` filter to a `view_b` query makes Cube `/v1/load` error with an unknown-member response — **any AdHoc filter on a multi-view dashboard turns the unrelated panels red**.

## Fix (Option 1)

- **`src/utils/viewSelection.ts`** — new `buildMemberViewMap(metadata)` (fully-qualified member → view).
- **`src/utils/normalizeCubeQuery.ts`** — infer the query's view from `dimensions ∪ measures ∪ panel-filters` (reusing `getViewSelectionState`) and keep only AdHoc filters whose member belongs to that view; drop the rest. Returns `droppedAdHocFilters`. Behavior matrix:
  - **No metadata (not loaded yet):** inject all AdHoc filters (prior behavior) — single-view dashboards are not regressed before metadata resolves.
  - **Metadata present, no view inferable (empty query):** skip AdHoc injection entirely.
  - **Otherwise:** keep same-view filters; drop cross-view ones (members absent from metadata are treated as non-matching and dropped).
- **`src/datasource.ts`** — cache view metadata (warmed in the constructor, refreshed by `getMetadata()`) so the **synchronous runtime path** `applyTemplateVariables` can scope by view; pass it to `normalizeCubeQuery`. This is what actually fixes the red-panels bug at query time (the preview path already had metadata).
- **`src/utils/buildCubeQuery.ts`** — `buildCubeQueryJson` now returns `{ json, droppedAdHocFilters }`.
- **`src/components/QueryEditor.tsx` + `SQLPreview.tsx`** — thread the dropped list into the SQL preview, which shows an info hint: **"Skipped N inapplicable AdHoc filter(s): view_b.region, …"** (also rendered when there is no SQL yet).
- **README** — documents the click-to-filter caveat (clicking `customer = BBC` on a `view_a` panel now only filters `view_a` panels).

### Design note (runtime metadata)

`applyTemplateVariables` is synchronous and had no metadata, so the DataSource now caches it (constructor prefetch + `getMetadata()` write-through). On the very first query before the cache warms, we fall back to prior behavior (inject all) — strictly no worse than today, and it self-heals once metadata loads.

## Interactions preserved

Shares `normalizeCubeQuery` with the #35 `$cubeTimeDimension` timeRange injection and the (kept, deprecated per #127) `getAdhocFilters` read — both verified unaffected by a dedicated test (cross-view AdHoc dropped **while** the dashboard time dimension is still injected).

## Cube SDK parity (docs/sdk-parity.md)

No change to Cube request/transport semantics — this only reduces the `filters` array we send to `/v1/load` to members valid for the queried view. It matches Cube's sealed-view model (a filter on a member outside the view is invalid and errors), and mirrors what Grafana's upcoming `getFiltersApplicability` (issue Option 4) will formalize. No divergence introduced.

## Scope

The optional `getTagKeys` view-name prefix (Option 1 step 4, overlaps #107) is intentionally **skipped** to keep scope tight — noted as a follow-up.

## Tests

- `normalizeCubeQuery.test.ts`: view-match keep, cross-view drop, mixed multi-view, view-inferred-from-panel-filters, no-view-skip, unknown-member drop, no-metadata keep-all, and the time-dim-injection interaction.
- `viewSelection.test.ts`: `buildMemberViewMap`.
- `buildCubeQuery.test.ts`: `droppedAdHocFilters` surfacing (same-view applied, cross-view reported).
- `SQLPreview.test.tsx`: hint plural/singular, hint-without-SQL, and no-hint-when-none.

## Verification (node 24.15.0 / npm 11.12.1)

- `npm run typecheck` ✅ · `npm run test:ci` ✅ 19 suites / **282** tests · `npm run lint` ✅ 0 errors (6 pre-existing deprecation warnings) · `npm run build` ✅

Frontend-only. Don't merge on my end — for the two-reviewer dual-review loop.
