### PR TITLE
chore: refresh dashboard-managed dev environment (Node 24)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ mapping, method selection, or progress fields, you **must**:
 
 ### Non-obvious notes
 
+- **Node version (engine-strict):** `.npmrc` sets `engine-strict=true` and `package.json` requires Node `>=24` / npm `>=11.12.1`, so `npm install`/`npm run *` hard-fail on the wrong Node. The Cloud VM's infra ships `/exec-daemon/node` (v22) first on `PATH`; the snapshot works around this by setting the nvm `default` alias to `24.18.1` and prepending it to `PATH` in `~/.bashrc`. Interactive/login shells (and the startup update script) therefore get Node 24 automatically — if you spawn a bare non-login shell and hit `EBADENGINE`, run `. "$NVM_DIR/nvm.sh"` (or use `bash -l`) to pick up Node 24. `mage` lives in `$(go env GOPATH)/bin`, also added to `PATH` via `~/.bashrc`.
+- On the Cloud VM the Docker host is `x86_64`, so build the backend with `mage -v build:linux` (produces `gpx_cube_linux_amd64`) before `docker compose up`.
 - Playwright E2E tests (`npm run e2e`) require services to be up first. Use `--reporter=list` to avoid the interactive HTML report blocking the terminal.
 - `mage -v` builds all 6 platform binaries by default. For faster local dev, build only the Linux binary matching your Docker host architecture:
   - **Apple Silicon (M1/M2/M3/M4):** `mage -v build:linuxARM64` — Docker runs ARM64 containers natively, so Grafana loads `gpx_cube_linux_arm64`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates and validates the dashboard-managed (snapshot) Cloud dev environment for this repo. The snapshot had drifted: the repo now pins **Node `>=24` / npm `>=11.12.1`** with `engine-strict=true` in `.npmrc` (commit #492 bumped Node to 24.18.1), but the VM defaulted to Node 22 and was missing `docker` and `mage`. That combination made `npm install` hard-fail on startup.

### VM / snapshot changes (not in this diff)
- Set the nvm `default` alias to `24.18.1` and prepend it ahead of the infra `/exec-daemon/node` (v22) in `~/.bashrc`, so login shells and the update script get Node 24 + npm 11.16.0.
- Installed `mage` (`v1.17.2`, matching `go.mod`) into `$(go env GOPATH)/bin` and added it to `PATH`.
- Installed Docker CE (28.5.2) with the `fuse-overlayfs` storage driver + iptables-legacy for docker-in-docker.

### Update script (runs on startup)
Minimal + idempotent — selects the repo-pinned Node via nvm, then refreshes deps:
```
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
NODE_BIN="$(dirname "$(nvm which default 2>/dev/null)" 2>/dev/null)"
[ -d "$NODE_BIN" ] && export PATH="$NODE_BIN:$PATH"
npm install
go mod download
```

### Repo change in this PR
- `AGENTS.md`: documents the non-obvious Node-24 / `engine-strict` gotcha (infra `/exec-daemon/node` is v22) and that the Cloud VM Docker host is `x86_64` (`mage -v build:linux`).

## Validation (end to end)
| Step | Command | Result |
|------|---------|--------|
| Frontend build | `npm run build` | ✅ webpack compiled |
| Backend build | `mage -v build:linux` | ✅ `gpx_cube_linux_amd64` |
| Services | `docker compose up --build -d` | ✅ Grafana:3000, Cube:4000, Postgres:5432 up |
| Lint | `npm run lint` | ✅ 0 errors (6 pre-existing deprecation warnings) |
| Typecheck | `npm run typecheck` | ✅ clean |
| Unit tests | `npm run test:ci` | ✅ 267/267 |
| Backend tests | `mage -v test` | ✅ pass |
| Plugin query (backend) | `POST /api/ds/query` | ✅ returned real Cube data frames |

### Hello-world
Built and ran a query in Grafana Explore against the **Cube** datasource (dimension `order_details.customers_first_name` + measure `order_details.count`), returning real rows (Adam: 5, Rose: 5, Paul: 4, …).

[grafana_cube_query_hello_world.mp4](https://cursor.com/agents/bc-c70ceaf4-b2c9-44de-973c-62fd6615f30c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrafana_cube_query_hello_world.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c70ceaf4-b2c9-44de-973c-62fd6615f30c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c70ceaf4-b2c9-44de-973c-62fd6615f30c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

