### PR TITLE
fix(adhoc): partition getTagValues scoping filters + time dimension by view (#498)

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -386,6 +386,68 @@ describe('DataSource', () => {
         });
       });
 
+      it('awaits getMetadata on a cold cache and uses it to partition (cold path)', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });
+
+        const datasource = createDataSource();
+        datasource.getCachedMetadata = jest.fn().mockReturnValue(null); // cold
+        datasource.getMetadata = jest.fn().mockResolvedValue(twoViewMetadata);
+
+        await datasource.getTagValues({
+          key: 'ad_campaigns.platform',
+          filters: [
+            { key: 'customers.location', operator: '=', value: 'uk' }, // cross-view -> drop
+            { key: 'ad_campaigns.region', operator: '=', value: 'emea' }, // same view -> keep
+          ],
+        });
+
+        expect(datasource.getMetadata).toHaveBeenCalledTimes(1);
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'ad_campaigns.platform',
+          filters: JSON.stringify([{ member: 'ad_campaigns.region', operator: 'equals', values: ['emea'] }]),
+          timeDimensions: undefined,
+        });
+      });
+
+      it('uses the cached metadata without re-fetching on a warm cache (warm path)', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });
+
+        const datasource = withTwoViews(); // getCachedMetadata returns metadata
+        datasource.getMetadata = jest.fn(); // must NOT be called
+
+        await datasource.getTagValues({
+          key: 'ad_campaigns.platform',
+          filters: [{ key: 'customers.location', operator: '=', value: 'uk' }],
+        });
+
+        expect(datasource.getMetadata).not.toHaveBeenCalled();
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'ad_campaigns.platform',
+          filters: undefined, // cross-view dropped using the cached metadata
+          timeDimensions: undefined,
+        });
+      });
+
+      it('skips the metadata fetch entirely when there are no filters and no timeRange', async () => {
+        mockGetResource.mockResolvedValue([]);
+        const datasource = withTwoViews();
+        const getCached = datasource.getCachedMetadata as jest.Mock;
+        datasource.getMetadata = jest.fn();
+        getCached.mockClear();
+
+        await datasource.getTagValues({ key: 'ad_campaigns.platform' });
+
+        expect(datasource.getMetadata).not.toHaveBeenCalled();
+        expect(getCached).not.toHaveBeenCalled();
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'ad_campaigns.platform',
+          filters: undefined,
+          timeDimensions: undefined,
+        });
+      });
+
       it('forwards scoping filters unchanged when metadata is unavailable (prior behavior)', async () => {
         mockGetResource.mockResolvedValue([]);
         mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -31,6 +31,18 @@ const createDataSource = (options: Partial<CubeDataSourceOptions> = {}) => {
 
   const datasource = new DataSource(instanceSettings);
   datasource.getResource = mockGetResource;
+  // Default single-view ("orders") metadata so getTagValues view-scoping (#498)
+  // is a no-op for same-view members. Tests that need cross-view / cold behavior
+  // override getCachedMetadata explicitly.
+  datasource.getCachedMetadata = jest.fn().mockReturnValue({
+    dimensions: [
+      { label: 'orders.status', value: 'orders.status', type: 'string', cube: 'orders' },
+      { label: 'orders.region', value: 'orders.region', type: 'string', cube: 'orders' },
+      { label: 'orders.customer', value: 'orders.customer', type: 'string', cube: 'orders' },
+      { label: 'orders.order_date', value: 'orders.order_date', type: 'time', cube: 'orders' },
+    ],
+    measures: [{ label: 'orders.count', value: 'orders.count', type: 'number', cube: 'orders' }],
+  });
   return datasource;
 };
 
@@ -241,6 +253,157 @@ describe('DataSource', () => {
         });
         // templateSrv must not even be consulted when there is no timeRange.
         expect(replace).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('view-scoping of scoping filters + time dimension (issue #498)', () => {
+      const twoViewMetadata = {
+        dimensions: [
+          { label: 'customers.location', value: 'customers.location', type: 'string', cube: 'customers' },
+          { label: 'customers.name', value: 'customers.name', type: 'string', cube: 'customers' },
+          { label: 'customers.created_at', value: 'customers.created_at', type: 'time', cube: 'customers' },
+          { label: 'ad_campaigns.platform', value: 'ad_campaigns.platform', type: 'string', cube: 'ad_campaigns' },
+          { label: 'ad_campaigns.region', value: 'ad_campaigns.region', type: 'string', cube: 'ad_campaigns' },
+        ],
+        measures: [{ label: 'ad_campaigns.clicks', value: 'ad_campaigns.clicks', type: 'number', cube: 'ad_campaigns' }],
+      };
+      const makeTimeRange = () => ({
+        from: { toISOString: () => '2018-03-01T00:00:00.000Z' },
+        to: { toISOString: () => '2018-03-31T23:59:59.000Z' },
+      });
+      const withTwoViews = () => {
+        const datasource = createDataSource();
+        datasource.getCachedMetadata = jest.fn().mockReturnValue(twoViewMetadata);
+        return datasource;
+      };
+
+      it('keeps same-view scoping filters and drops cross-view ones', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });
+        const datasource = withTwoViews();
+
+        await datasource.getTagValues({
+          key: 'ad_campaigns.platform',
+          filters: [
+            { key: 'customers.location', operator: '=', value: 'uk' }, // cross-view -> drop
+            { key: 'ad_campaigns.region', operator: '=', value: 'emea' }, // same view -> keep
+          ],
+        });
+
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'ad_campaigns.platform',
+          filters: JSON.stringify([{ member: 'ad_campaigns.region', operator: 'equals', values: ['emea'] }]),
+          timeDimensions: undefined,
+        });
+      });
+
+      it('drops ALL scoping filters when every one is cross-view (unscoped beats error)', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });
+        const datasource = withTwoViews();
+
+        await datasource.getTagValues({
+          key: 'ad_campaigns.platform',
+          filters: [{ key: 'customers.location', operator: '=', value: 'uk' }],
+        });
+
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'ad_campaigns.platform',
+          filters: undefined,
+          timeDimensions: undefined,
+        });
+      });
+
+      it('drops ALL scoping filters when the key itself is not in metadata (stale/unknown)', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });
+        const datasource = withTwoViews();
+
+        await datasource.getTagValues({
+          key: 'gone.member',
+          filters: [{ key: 'ad_campaigns.region', operator: '=', value: 'emea' }],
+        });
+
+        // Cannot resolve the key's view -> attempt unscoped rather than error.
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'gone.member',
+          filters: undefined,
+          timeDimensions: undefined,
+        });
+      });
+
+      it('represents the query-builder useMemberValuesQuery surface: cross-view AdHoc dropped', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });
+        const datasource = withTwoViews();
+
+        // useMemberValuesQuery threads active dashboard AdHoc filters into the
+        // same getTagValues lookup; a cross-view one must not reach the backend.
+        await datasource.getTagValues({
+          key: 'customers.name',
+          filters: [{ key: 'ad_campaigns.platform', operator: '=', value: 'google' }],
+        });
+
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'customers.name',
+          filters: undefined,
+          timeDimensions: undefined,
+        });
+      });
+
+      it('injects $cubeTimeDimension when it is in the SAME view as key', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({
+          replace: (s: string) => (s === '$cubeTimeDimension' ? 'customers.created_at' : s),
+        });
+        const datasource = withTwoViews();
+
+        await datasource.getTagValues({ key: 'customers.name', timeRange: makeTimeRange() as any });
+
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'customers.name',
+          filters: undefined,
+          timeDimensions: JSON.stringify([
+            { dimension: 'customers.created_at', dateRange: ['2018-03-01T00:00:00.000Z', '2018-03-31T23:59:59.000Z'] },
+          ]),
+        });
+      });
+
+      it('drops $cubeTimeDimension when it is in a DIFFERENT view than key (#35 interaction)', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({
+          replace: (s: string) => (s === '$cubeTimeDimension' ? 'customers.created_at' : s),
+        });
+        const datasource = withTwoViews();
+
+        // key in ad_campaigns view, time dimension in customers view -> drop it.
+        await datasource.getTagValues({ key: 'ad_campaigns.platform', timeRange: makeTimeRange() as any });
+
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'ad_campaigns.platform',
+          filters: undefined,
+          timeDimensions: undefined,
+        });
+      });
+
+      it('forwards scoping filters unchanged when metadata is unavailable (prior behavior)', async () => {
+        mockGetResource.mockResolvedValue([]);
+        mockGetTemplateSrv.mockReturnValue({ replace: (s: string) => s });
+        const datasource = createDataSource();
+        // No metadata at all: cache null and getMetadata fails.
+        datasource.getCachedMetadata = jest.fn().mockReturnValue(null);
+        datasource.getMetadata = jest.fn().mockRejectedValue(new Error('no meta'));
+
+        await datasource.getTagValues({
+          key: 'ad_campaigns.platform',
+          filters: [{ key: 'customers.location', operator: '=', value: 'uk' }],
+        });
+
+        expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+          key: 'ad_campaigns.platform',
+          filters: JSON.stringify([{ member: 'customers.location', operator: 'equals', values: ['uk'] }]),
+          timeDimensions: undefined,
+        });
       });
     });
   });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -5,6 +5,7 @@ import { mergeMap } from 'rxjs/operators';
 
 import { CubeQuery, CubeDataSourceOptions, DEFAULT_QUERY, Operator } from './types';
 import { normalizeCubeQuery } from './utils/normalizeCubeQuery';
+import { buildMemberViewMap } from './utils/viewSelection';
 import type { MetadataResponse } from './queries';
 
 export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceOptions> {
@@ -107,22 +108,29 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
   // Scopes results by any existing AdHoc filters (like Prometheus does) and,
   // when $cubeTimeDimension is configured, by the dashboard time range Grafana
   // provides in options.timeRange (parity with Prometheus/Loki/Elasticsearch).
-  getTagValues(options: {
+  async getTagValues(options: {
     key: string;
     filters?: Array<{ key: string; operator: string; value: string; values?: string[] }>;
     // Context time range Grafana passes to getTagValues since v10.3.
     timeRange?: TimeRange;
   }) {
-    // Convert existing filters to Cube format for scoping
-    const scopingFilters = options.filters?.length
-      ? options.filters.map((filter) => ({
-          member: filter.key,
-          operator: this.mapOperator(filter.operator),
-          values: filter.values && filter.values.length > 0 ? filter.values : [filter.value],
-        }))
-      : undefined;
+    // Cube views are sealed namespaces: a scoping filter (or $cubeTimeDimension)
+    // whose member lives in a different view than `key` makes /v1/load error (no
+    // join path). Resolve view metadata so we can keep only same-view scoping
+    // (issue #498, the value-lookup twin of #495). getTagValues is async, so we
+    // can await; prefer the cache (Grafana calls getTagKeys -> getMetadata first,
+    // so it is normally already warm) and only fetch when cold.
+    let metadata = this.getCachedMetadata();
+    if (!metadata) {
+      try {
+        metadata = await this.getMetadata();
+      } catch {
+        metadata = null;
+      }
+    }
 
-    const timeDimensions = this.buildTagValueTimeDimensions(options.timeRange);
+    const scopingFilters = this.partitionScopingFiltersByView(options.key, options.filters, metadata);
+    const timeDimensions = this.buildTagValueTimeDimensions(options.key, options.timeRange, metadata);
 
     return this.getResource('tag-values', {
       key: options.key,
@@ -131,12 +139,54 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
     });
   }
 
+  // Keep only scoping filters whose member belongs to the same Cube view as the
+  // looked-up `key`; drop cross-view ones (which would error). Mirrors #495's
+  // sealed-view doctrine on the value-lookup path (issue #498).
+  private partitionScopingFiltersByView(
+    key: string,
+    filters: Array<{ key: string; operator: string; value: string; values?: string[] }> | undefined,
+    metadata: MetadataResponse | null
+  ): Array<{ member: string; operator: Operator; values: string[] }> | undefined {
+    if (!filters?.length) {
+      return undefined;
+    }
+
+    const toCube = (filter: { key: string; operator: string; value: string; values?: string[] }) => ({
+      member: filter.key,
+      operator: this.mapOperator(filter.operator),
+      values: filter.values && filter.values.length > 0 ? filter.values : [filter.value],
+    });
+
+    // Without metadata we cannot resolve views; forward as-is (prior behavior).
+    if (!metadata) {
+      return filters.map(toCube);
+    }
+
+    const memberToView = buildMemberViewMap(metadata);
+    const keyView = memberToView.get(key);
+
+    // Edge case: `key` itself isn't in metadata (stale filter after a model
+    // change / unknown). We can't determine its view, so drop ALL scoping
+    // filters (attempt unscoped) rather than forward all and guarantee a
+    // cross-view error.
+    if (keyView === undefined) {
+      return undefined;
+    }
+
+    const applicable = filters.filter((filter) => memberToView.get(filter.key) === keyView).map(toCube);
+    return applicable.length > 0 ? applicable : undefined;
+  }
+
   // Build a Cube time dimension filter for tag-value lookups from the dashboard
   // time range. Requires BOTH a configured $cubeTimeDimension dashboard variable
   // (Cube needs to know WHICH dimension carries time, unlike Prometheus/Loki) and
   // a timeRange from Grafana. Returns undefined when either is missing, so
   // behavior is unchanged when the variable is not set (issue #35).
-  private buildTagValueTimeDimensions(timeRange?: TimeRange): Array<{ dimension: string; dateRange: [string, string] }> | undefined {
+  private buildTagValueTimeDimensions(
+    key: string,
+    timeRange: TimeRange | undefined,
+    metadata: MetadataResponse | null
+  ): Array<{ dimension: string; dateRange: [string, string] }> | undefined {
     if (!timeRange) {
       return undefined;
     }
@@ -144,6 +194,17 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
     const dimension = getTemplateSrv().replace('$cubeTimeDimension');
     if (!dimension || dimension === '$cubeTimeDimension') {
       return undefined;
+    }
+
+    // Only inject the dashboard time dimension if it lives in the SAME view as
+    // `key`; a cross-view time dimension errors just like a cross-view filter
+    // (issue #498, #35 interaction). Without metadata we forward as before.
+    if (metadata) {
+      const memberToView = buildMemberViewMap(metadata);
+      const keyView = memberToView.get(key);
+      if (keyView === undefined || memberToView.get(dimension) !== keyView) {
+        return undefined;
+      }
     }
 
     const from = timeRange.from?.toISOString?.();

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -114,6 +114,16 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
     // Context time range Grafana passes to getTagValues since v10.3.
     timeRange?: TimeRange;
   }) {
+    // Nothing to partition or scope (no scoping filters and no time range): skip
+    // the metadata fetch entirely — there is nothing to drop or view-check.
+    if (!options.filters?.length && !options.timeRange) {
+      return this.getResource('tag-values', {
+        key: options.key,
+        filters: undefined,
+        timeDimensions: undefined,
+      });
+    }
+
     // Cube views are sealed namespaces: a scoping filter (or $cubeTimeDimension)
     // whose member lives in a different view than `key` makes /v1/load error (no
     // join path). Resolve view metadata so we can keep only same-view scoping


### PR DESCRIPTION
Fixes #498. Implements **Option 1** — the value-lookup twin of #495.

> **Stacked on #495.** This branch is based on `fix/307-drop-inapplicable-adhoc-filters` (#495) so it can reuse `buildMemberViewMap` + the datasource metadata cache, and so the diff here shows **only the #498 delta** (`src/datasource.ts` + `src/datasource.test.ts`). Once #495 merges I'll rebase onto `main` and retarget this PR.

## Problem

When a user opens an AdHoc filter's value dropdown, Grafana calls `getTagValues({ key, filters })` where `filters` is every *other* active AdHoc filter. We forwarded them all to the Cube `tag-values` resource. Because Cube views are sealed namespaces, a scoping filter (or `$cubeTimeDimension`) whose member lives in a **different view** than `key` makes `/v1/load` error (no join path) — the value dropdown breaks.

## Fix (Option 1, mirrors #495)

`src/datasource.ts`:

- **`getTagValues` is now `async`** — prefers the cached view metadata and `await`s `getMetadata()` only when cold (Grafana calls `getTagKeys()` → `getMetadata()` before any dropdown opens, so it's normally already warm; no cold-cache race, and no redundant `/v1/meta` per dropdown).
- **`partitionScopingFiltersByView`** — resolve the view of `options.key` via `buildMemberViewMap`, keep only scoping filters whose member is in the **same view**, drop the rest.
- **Edge case** — if `key` itself isn't in metadata (stale filter after a model change / unknown), drop **all** scoping filters (attempt *unscoped*) rather than forward all and guarantee a cross-view error.
- **`buildTagValueTimeDimensions`** now takes `key` + metadata and only injects `$cubeTimeDimension` when it's in the **same view** as `key` (else drops it) — so the #35 time-range half of the bug can't survive.
- **No metadata available** → forward as before (prior behavior).

This fixes all **three** surfaces at the single `getTagValues` choke point: the dashboard AdHoc bar, the query-builder `FilterField` (`useMemberValuesQuery`, the #32 wiring), and time-range scoping.

## Cube SDK parity (docs/sdk-parity.md)

Mirrors the sealed-view doctrine #495 established: an AdHoc filter only means anything within its own view. **Documented tradeoff** (per the issue): the result is silently *unscoped* rather than scoped-cross-view — but with no join path there is genuinely no way to scope, and unscoped values beat an error; the plain `{ text }` tag-value contract gives nowhere to render a hint (that's the eventual upstream `getFiltersApplicability` UX). No change to Cube request/transport semantics beyond shrinking the forwarded `filters` / `timeDimensions` to view-valid members.

## Tests (`src/datasource.test.ts`, +7)

same-view keep + cross-view drop; all-cross-view → drop all; `key` not in metadata → drop all; the `useMemberValuesQuery` surface (cross-view AdHoc dropped); `$cubeTimeDimension` same-view keep vs cross-view drop (#35 interaction); and no-metadata → forward-all (prior behavior). Existing getTagValues tests updated with single-view (`orders`) metadata so same-view forwarding is preserved.

## Verification (node 24.15.0 / npm 11.12.1)

- `npm run typecheck` ✅ · `npm run test:ci` ✅ 19 suites / **296** tests · `npm run lint` ✅ 0 errors (6 pre-existing warnings) · `npm run build` ✅

Frontend-only. Don't merge on my end — for the two-reviewer dual-review loop, and after #495 merges I'll rebase onto main.
