### PR TITLE
chore(dev-env): add disjoint Cube views + cross-view AdHoc demo dashboards

### DIFF
--- a/dev-environment/cube/model/views/customer_directory.yml
+++ b/dev-environment/cube/model/views/customer_directory.yml
@@ -1,0 +1,14 @@
+views:
+  - name: customer_directory
+
+    cubes:
+      - join_path: customers
+        includes:
+          - first_name
+          - last_name
+          - email
+          - is_active
+          - created_at
+          - customer_segment
+          - count
+        prefix: false

--- a/dev-environment/cube/model/views/payments_overview.yml
+++ b/dev-environment/cube/model/views/payments_overview.yml
@@ -1,0 +1,14 @@
+views:
+  - name: payments_overview
+
+    cubes:
+      - join_path: payments
+        includes:
+          - payment_method
+          - currency
+          - is_successful
+          - created_at
+          - amount
+          - count
+          - total_amount
+        prefix: false

--- a/provisioning/dashboards/demo-cross-view-adhoc.json
+++ b/provisioning/dashboards/demo-cross-view-adhoc.json
@@ -1,0 +1,50 @@
+{
+  "uid": "demo-cross-view-adhoc",
+  "title": "Demo: cross-view AdHoc filters (#498)",
+  "editable": true,
+  "schemaVersion": 41,
+  "time": { "from": "2017-01-01T00:00:00.000Z", "to": "2017-05-01T00:00:00.000Z" },
+  "templating": {
+    "list": [
+      {
+        "name": "adhocFilters",
+        "label": "Filters",
+        "type": "adhoc",
+        "datasource": { "type": "grafana-cube-datasource", "uid": "grafana-cube-datasource" },
+        "filters": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "table",
+      "title": "View A: customer_directory - customers by segment",
+      "datasource": { "type": "grafana-cube-datasource", "uid": "grafana-cube-datasource" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-cube-datasource", "uid": "grafana-cube-datasource" },
+          "dimensions": ["customer_directory.customer_segment"],
+          "measures": ["customer_directory.count"],
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": {} }, "overrides": [] }
+    },
+    {
+      "type": "table",
+      "title": "View B: payments_overview - amount by payment method",
+      "datasource": { "type": "grafana-cube-datasource", "uid": "grafana-cube-datasource" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-cube-datasource", "uid": "grafana-cube-datasource" },
+          "dimensions": ["payments_overview.payment_method"],
+          "measures": ["payments_overview.total_amount"],
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "custom": {} }, "overrides": [] }
+    }
+  ]
+}

--- a/provisioning/dashboards/demo-cross-view-timedim.json
+++ b/provisioning/dashboards/demo-cross-view-timedim.json
@@ -1,0 +1,41 @@
+{
+  "uid": "demo-cross-view-timedim",
+  "title": "Demo: cross-view $cubeTimeDimension in value lookups (#498 / #35)",
+  "editable": true,
+  "schemaVersion": 41,
+  "time": { "from": "2017-01-01T00:00:00.000Z", "to": "2017-05-01T00:00:00.000Z" },
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": { "text": "customer_directory.created_at", "value": "customer_directory.created_at" },
+        "description": "This field will have the Dashboard Time-range applied to it as a filter",
+        "label": "Time-range filtering field",
+        "name": "cubeTimeDimension",
+        "options": [
+          { "selected": true, "text": "customer_directory.created_at", "value": "customer_directory.created_at" }
+        ],
+        "query": "customer_directory.created_at",
+        "type": "custom"
+      },
+      {
+        "name": "adhocFilters",
+        "label": "Filters",
+        "type": "adhoc",
+        "datasource": { "type": "grafana-cube-datasource", "uid": "grafana-cube-datasource" },
+        "filters": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "Scenario",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "options": {
+        "mode": "markdown",
+        "content": "The dashboard time dimension is **customer_directory.created_at** (view A).\n\nOpen the **Filters** bar and pick the key **payments_overview.payment_method** (view B), then open its value dropdown.\n\nThere are no other ad-hoc filters set: the only thing the value lookup can send to Cube is the dashboard time range on a dimension from a *different* view."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Optional dev-environment fixtures, split out of the demo work for #499 so that PR stays frontend-only. Merge or close as you prefer.

## Why

The dev Cube model only had **one** view (`order_details`), so none of the cross-view AdHoc behavior we've been fixing (#307 / #495 and #498 / #499) could be reproduced locally. Adding a second view isn't enough either: `order_details` (rooted at `orders`) and a `payments` view still resolve to a valid join path, so Cube happily answers cross-view queries. The failure only appears between views whose underlying cubes have **no** join path.

## What

- `dev-environment/cube/model/views/customer_directory.yml` — view over `customers` (which declares `joins: []`).
- `dev-environment/cube/model/views/payments_overview.yml` — view over `payments`.

  Neither cube can reach the other (only `orders` joins both), so a query mixing their members fails with Cube's real error:

  ```
  Can't find join path to join 'payments', 'customers'
  ```

- `provisioning/dashboards/demo-cross-view-adhoc.json` — one panel per view plus an AdHoc filter bar; reproduces the #498 scoping-filter case (filter in view A, value dropdown in view B).
- `provisioning/dashboards/demo-cross-view-timedim.json` — `$cubeTimeDimension` set to a view-A dimension with no other filters; reproduces the #35 interaction half of #498 in isolation.

## Verification

- Both dashboards provision cleanly and reproduce the pre-fix errors on `main`, and both work on the #499 branch.
- `npm run e2e -- --reporter=list` — 10 passed, 1 skipped with these fixtures present, so the extra views don't disturb the existing suite.

## Known rough edge

On `demo-cross-view-timedim` any *panel* querying view B would still error, because `$cubeTimeDimension` is injected into panel queries without a view check — that's a separate gap from #498 (which only covers the value-lookup path). The dashboard deliberately uses a text panel to keep the demo focused on the value dropdown.

## Cube SDK parity

No plugin behavior changes — data-model and dashboard fixtures only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb974-18fe-77d3-b15f-6e0277792263?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb974-18fe-77d3-b15f-6e0277792263&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

