### PR TITLE
docs(parity): record why cross-view AdHoc filters are dropped, not attempted

### DIFF
--- a/docs/sdk-parity.md
+++ b/docs/sdk-parity.md
@@ -55,8 +55,9 @@ sources of truth (the Cube monorepo is cloned alongside this repo at `../cube`):
 
 ## Divergence log
 
-Behaviors where the Go backend intentionally differs from `@cubejs-client/core`.
-Everything not listed here is expected to mirror the SDK.
+Behaviors where this plugin intentionally differs from `@cubejs-client/core` —
+mostly in the Go backend, plus frontend query shaping where it changes what we
+send to Cube. Everything not listed here is expected to mirror the SDK.
 
 ### How the SDK actually retries (precedence matters)
 
@@ -148,3 +149,31 @@ SDK-aligned, **not** a divergence, so it is not listed below.
   duplicate Grafana's refresh mechanism.
 - **User impact:** none for standard dashboards; real-time streaming panels are
   not supported by this datasource.
+
+### 5. Cross-view AdHoc filters are dropped rather than attempted
+
+- **SDK behavior:** an SDK client sends whatever filters the caller supplies.
+  Cube resolves view members down to their underlying cubes and **will** join
+  across views whenever its join graph has a directed path; only a genuinely
+  disjoint pair fails, with `Can't find join path to join 'x', 'y'`.
+- **Divergence:** we drop AdHoc filters (and `$cubeTimeDimension` on value
+  lookups) whose member belongs to a different view than the query, without
+  attempting the request — forgoing joins Cube would have performed
+  ([#307](https://github.com/grafana/grafana-cube-datasource/issues/307),
+  [#498](https://github.com/grafana/grafana-cube-datasource/issues/498)).
+- **Rationale:** views are curated marts, and "a filter means something only
+  inside its own view" is predictable. "…unless the model happens to have a
+  join path" makes behavior depend on invisible join topology, so two
+  identical-looking dashboards would behave differently. Attempt-then-retry
+  (Option 4 in #498) was considered and rejected: Cube returns no error code,
+  so detection means matching the error string, and results would silently
+  change when a modeler adds an unrelated join. Genuinely global filters are a
+  modeling problem — expose the shared dimension in each view.
+- **User impact:** in a multi-view dashboard, a filter set on view A never
+  narrows panels or value lookups in view B, even where Cube could have joined
+  them. Users see the unscoped result rather than an error; the SQL preview
+  reports which filters were skipped.
+- **Tests:** `normalizeCubeQuery AdHoc view-scoping (issue #307)` in
+  `src/utils/normalizeCubeQuery.test.ts`, and the `getTagValues` view-partition
+  cases in `src/datasource.test.ts` (e.g. "keeps same-view scoping filters and
+  drops cross-view ones").


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs only. Adds divergence entry 5 to `docs/sdk-parity.md`.

## Why

While demoing #499 I confirmed empirically that Cube does **not** treat views as sealed for query purposes: it resolves view members down to their underlying cubes and joins across views whenever the join graph has a directed path. Only a genuinely disjoint pair fails.

Measured against the dev stack (`customers` and `payments` are joined only *through* `orders`, so neither can reach the other):

| Query | Result |
|---|---|
| `order_details.status` values scoped by `customer_directory.customer_segment` | succeeds, 4 statuses |
| same, unscoped (what we send today) | succeeds, 5 statuses |
| `payments_overview` panel filtered by `order_details.status` | succeeds |
| `payments_overview` filtered by `customer_directory.customer_segment` | `Can't find join path to join 'payments', 'customers'` |

So the sealed-view rule from #307 / #495 / #498 / #499 forgoes joins Cube would have performed. That's a deliberate choice, not an oversight — but nothing recorded it, and it is easy to rediscover and mistake for a bug.

## What the entry says

That we drop rather than attempt; that predictability beats join-topology-dependent behavior; that attempt-then-retry (Option 4 in #498) was considered and rejected because Cube exposes no error code for this (detection would mean matching `Can't find join path…` as a string) and because results would silently change when a modeler adds an unrelated join; and that genuinely global filters are a modeling problem — expose the shared dimension in each view.

Also widens the divergence-log preamble, which claimed the log only covers the Go backend, to include frontend query shaping where it changes what we send to Cube.

## Cube SDK parity

This PR *is* the parity paperwork for an existing divergence. No behavior change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb974-18fe-77d3-b15f-6e0277792263?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb974-18fe-77d3-b15f-6e0277792263&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

