### PR TITLE
fix(adhoc): source SQL-preview filters from props.data.request.filters (#506)

### DIFF
--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -1060,6 +1060,83 @@ describe('QueryEditor', () => {
       });
     });
 
+    it('sources SQL-preview AdHoc filters from props.data.request.filters and refreshes when they change (#506)', async () => {
+      // No dashboard variables -> request.filters must be the source of truth.
+      mockGetTemplateSrv.mockReturnValue({
+        replace: jest.fn((value: string) => value),
+        getVariables: jest.fn(() => []),
+        getAdhocFilters: jest.fn(() => []),
+      });
+
+      const datasource = createMockDataSource();
+      const query = createMockQuery({ dimensions: ['orders.status'], measures: ['orders.count'] });
+      const dataWith = (value: string) =>
+        ({ request: { filters: [{ key: 'orders.status', operator: '=', value }] } } as any);
+
+      const { rerender } = setup(
+        <QueryEditor
+          query={query}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={datasource}
+          data={dataWith('completed')}
+        />
+      );
+
+      await waitFor(() => {
+        const call = (datasource.getResource as jest.Mock).mock.calls.find((c: unknown[]) => c[0] === 'sql');
+        expect(call).toBeDefined();
+        expect(JSON.parse(call![1].query).filters).toEqual([
+          { member: 'orders.status', operator: 'equals', values: ['completed'] },
+        ]);
+      });
+
+      (datasource.getResource as jest.Mock).mockClear();
+
+      // Applied filters change (a new query ran) -> preview memo refreshes.
+      rerender(
+        <QueryEditor
+          query={query}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={datasource}
+          data={dataWith('pending')}
+        />
+      );
+
+      await waitFor(() => {
+        const call = (datasource.getResource as jest.Mock).mock.calls.find((c: unknown[]) => c[0] === 'sql');
+        expect(call).toBeDefined();
+        expect(JSON.parse(call![1].query).filters).toEqual([
+          { member: 'orders.status', operator: 'equals', values: ['pending'] },
+        ]);
+      });
+    });
+
+    it('falls back to getVariables for the preview before the first run (data undefined, #506 gotcha)', async () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: jest.fn((value: string) => value),
+        getVariables: jest.fn(() => [
+          { type: 'adhoc', datasource: { uid: 'test-uid' }, filters: [{ key: 'orders.status', operator: '=', value: 'from_var' }] },
+        ]),
+        getAdhocFilters: jest.fn(() => []),
+      });
+
+      const datasource = createMockDataSource();
+      const query = createMockQuery({ dimensions: ['orders.status'], measures: ['orders.count'] });
+
+      // No data prop -> request.filters undefined -> must fall back to getVariables.
+      setup(<QueryEditor query={query} onChange={mockOnChange} onRunQuery={mockOnRunQuery} datasource={datasource} />);
+
+      await waitFor(() => {
+        const call = (datasource.getResource as jest.Mock).mock.calls.find((c: unknown[]) => c[0] === 'sql');
+        expect(call).toBeDefined();
+        expect(JSON.parse(call![1].query).filters).toEqual([
+          { member: 'orders.status', operator: 'equals', values: ['from_var'] },
+        ]);
+      });
+    });
+
     it('should recompute SQL preview when dashboard time range changes', async () => {
       const initialFrom = Date.now() - 3600000;
       const initialTo = Date.now();

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { InlineField, Input, Alert, MultiSelect, Text, Field, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { AdHocVariableFilter, GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from '../datasource';
 import { CubeDataSourceOptions, CubeQuery, CubeFilter, isCubeFilter } from '../types';
@@ -26,15 +26,25 @@ type Props = QueryEditorProps<DataSource, CubeQuery, CubeDataSourceOptions>;
  * Without surfacing these as useMemo dependencies, the SQL preview goes stale
  * when dashboard-level values change. See grafana/semantic-layer#13.
  */
-function useCubeQueryJson(query: CubeQuery, datasource: DataSource): BuiltCubeQuery {
+function useCubeQueryJson(
+  query: CubeQuery,
+  datasource: DataSource,
+  // The editor's props.data.request.filters — the AdHoc filters the last query
+  // actually ran with (Torkel's supported editor path, issue #506).
+  requestFilters?: AdHocVariableFilter[]
+): BuiltCubeQuery {
   const templateSrv = getTemplateSrv();
-  // Snapshot the RESOLVED AdHoc filters (issue #127) so the SQL preview
-  // re-renders when filters change. resolveAdHocFilters reads dashboard AdHoc
-  // variables first and only touches the deprecated getAdhocFilters as a
-  // conditional fallback, so normal scenes editing does not emit the
-  // deprecation warning (unlike calling getAdhocFilters unconditionally here).
+  // Snapshot the RESOLVED AdHoc filters so the SQL preview re-renders when the
+  // applied filters change. Precedence mirrors the runtime resolveAdHocFilters
+  // (issues #127/#506):
+  //   1. props.data.request.filters (post-run, canonical: matches execution)
+  //   2. getTemplateSrv().getVariables() adhoc vars (immediate / pre-run state)
+  //   3. deprecated getAdhocFilters() (older Grafana only)
+  // GOTCHA: data.request.filters is only populated AFTER a query runs; on first
+  // open / pre-run it is empty/undefined, so resolveAdHocFilters falls back to
+  // getVariables() and the preview still shows AdHoc WHERE before first execution.
   const adHocFiltersKey = JSON.stringify(
-    resolveAdHocFilters({ name: datasource.name, uid: datasource.uid })
+    resolveAdHocFilters({ name: datasource.name, uid: datasource.uid }, requestFilters)
   );
   const cubeTimeDimension = templateSrv.replace('$cubeTimeDimension', {});
   const fromTime = templateSrv.replace('$__from', {});
@@ -46,7 +56,7 @@ function useCubeQueryJson(query: CubeQuery, datasource: DataSource): BuiltCubeQu
   const { data: metadata } = useMetadataQuery({ datasource });
 
   return useMemo(
-    () => buildCubeQueryJson(query, datasource, metadata),
+    () => buildCubeQueryJson(query, datasource, metadata, requestFilters),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [query, datasource, adHocFiltersKey, cubeTimeDimension, fromTime, toTime, metadata]
   );
@@ -54,10 +64,18 @@ function useCubeQueryJson(query: CubeQuery, datasource: DataSource): BuiltCubeQu
 
 export function QueryEditor(props: Props) {
   const { query, datasource } = props;
+  const requestFilters = props.data?.request?.filters;
   const unsupportedFeatures = useMemo(() => detectUnsupportedFeatures(query), [query]);
 
   if (unsupportedFeatures.length > 0) {
-    return <UnsupportedQueryEditor query={query} datasource={datasource} reasons={unsupportedFeatures} />;
+    return (
+      <UnsupportedQueryEditor
+        query={query}
+        datasource={datasource}
+        reasons={unsupportedFeatures}
+        requestFilters={requestFilters}
+      />
+    );
   }
 
   return <VisualQueryEditor {...props} />;
@@ -72,12 +90,14 @@ function UnsupportedQueryEditor({
   query,
   datasource,
   reasons,
+  requestFilters,
 }: {
   query: CubeQuery;
   datasource: DataSource;
   reasons: string[];
+  requestFilters?: AdHocVariableFilter[];
 }) {
-  const { json: cubeQueryJson, droppedAdHocFilters } = useCubeQueryJson(query, datasource);
+  const { json: cubeQueryJson, droppedAdHocFilters } = useCubeQueryJson(query, datasource, requestFilters);
   const { data: compiledSql, isLoading: compiledSqlIsLoading } = useCompiledSqlQuery({
     datasource,
     cubeQueryJson,
@@ -106,9 +126,10 @@ function UnsupportedQueryEditor({
  * The full visual query builder with dimensions, measures, filters,
  * ordering, and SQL preview.
  */
-function VisualQueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+function VisualQueryEditor({ query, onChange, onRunQuery, datasource, data: panelData }: Props) {
   const styles = useStyles2(getStyles);
-  const { json: cubeQueryJson, droppedAdHocFilters } = useCubeQueryJson(query, datasource);
+  const requestFilters = panelData?.request?.filters;
+  const { json: cubeQueryJson, droppedAdHocFilters } = useCubeQueryJson(query, datasource, requestFilters);
 
   const { data, isLoading: metadataIsLoading, isError: metadataIsError } = useMetadataQuery({ datasource });
   const metadata = data ?? { dimensions: [], measures: [] };

--- a/src/utils/buildCubeQuery.test.ts
+++ b/src/utils/buildCubeQuery.test.ts
@@ -12,6 +12,7 @@ const mockGetTemplateSrv = getTemplateSrv as jest.Mock;
 const createDatasourceStub = () => {
   return {
     name: 'Test Cube',
+    uid: 'test-uid',
     mapOperator: jest.fn((operator: string) => {
       if (operator === '!=') {
         return Operator.NotEquals;
@@ -184,5 +185,72 @@ describe('buildCubeQueryJson', () => {
     // apply once a dimension/measure is chosen) -> no misleading hint.
     expect(json).toBe('');
     expect(droppedAdHocFilters).toEqual([]);
+  });
+
+  describe('explicit request.filters precedence for the SQL preview (issue #506)', () => {
+    const query: CubeQuery = { refId: 'A', dimensions: ['orders.status'], measures: ['orders.count'] };
+    const adhocVar = (value: string) => ({
+      type: 'adhoc',
+      datasource: { uid: 'test-uid' },
+      filters: [{ key: 'orders.status', operator: '=', value }],
+    });
+
+    it('uses explicit request.filters over dashboard variables and the deprecated API', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (v: string) => v,
+        getVariables: () => [adhocVar('FROM_VAR')],
+        getAdhocFilters: () => [{ key: 'orders.status', operator: '=', value: 'FROM_DEPRECATED' }],
+      });
+
+      const { json } = buildCubeQueryJson(query, createDatasourceStub(), undefined, [
+        { key: 'orders.status', operator: '=', value: 'FROM_REQUEST' },
+      ]);
+
+      expect(JSON.parse(json).filters).toEqual([
+        { member: 'orders.status', operator: 'equals', values: ['FROM_REQUEST'] },
+      ]);
+    });
+
+    it('falls back to dashboard variables when request.filters is undefined (pre-run / first open)', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (v: string) => v,
+        getVariables: () => [adhocVar('FROM_VAR')],
+        getAdhocFilters: () => [{ key: 'orders.status', operator: '=', value: 'FROM_DEPRECATED' }],
+      });
+
+      const { json } = buildCubeQueryJson(query, createDatasourceStub(), undefined, undefined);
+
+      expect(JSON.parse(json).filters).toEqual([
+        { member: 'orders.status', operator: 'equals', values: ['FROM_VAR'] },
+      ]);
+    });
+
+    it('falls back to dashboard variables when request.filters is an empty array', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (v: string) => v,
+        getVariables: () => [adhocVar('FROM_VAR')],
+        getAdhocFilters: () => [],
+      });
+
+      const { json } = buildCubeQueryJson(query, createDatasourceStub(), undefined, []);
+
+      expect(JSON.parse(json).filters).toEqual([
+        { member: 'orders.status', operator: 'equals', values: ['FROM_VAR'] },
+      ]);
+    });
+
+    it('falls back to the deprecated API when there is no request.filters and no variables', () => {
+      mockGetTemplateSrv.mockReturnValue({
+        replace: (v: string) => v,
+        getVariables: () => [],
+        getAdhocFilters: () => [{ key: 'orders.status', operator: '=', value: 'FROM_DEPRECATED' }],
+      });
+
+      const { json } = buildCubeQueryJson(query, createDatasourceStub(), undefined, undefined);
+
+      expect(JSON.parse(json).filters).toEqual([
+        { member: 'orders.status', operator: 'equals', values: ['FROM_DEPRECATED'] },
+      ]);
+    });
   });
 });

--- a/src/utils/buildCubeQuery.ts
+++ b/src/utils/buildCubeQuery.ts
@@ -3,6 +3,7 @@ import { DataSource } from '../datasource';
 import { CubeFilter, CubeFilterItem, CubeQuery, UNARY_OPERATORS, isCubeFilter, isCubeAndFilter, isCubeOrFilter } from '../types';
 import { normalizeCubeQuery } from './normalizeCubeQuery';
 import type { ViewSelectionMetadata } from './viewSelection';
+import type { AdHocFilter } from './adHocFilters';
 
 export interface BuiltCubeQuery {
   /** The Cube query JSON, or '' when the query has no dimensions/measures. */
@@ -27,13 +28,20 @@ export function buildCubeQueryJson(
   // Optional explicit view metadata. Callers (e.g. the SQL preview) pass the
   // reactive useMetadataQuery result so the "skipped N" hint updates when
   // metadata loads; falls back to the datasource cache otherwise (issue #307).
-  metadata?: ViewSelectionMetadata
+  metadata?: ViewSelectionMetadata,
+  // Optional explicit AdHoc filters. The SQL preview passes the editor's
+  // props.data.request.filters (the filters the last query actually ran with)
+  // as the primary source; resolveAdHocFilters falls back to dashboard AdHoc
+  // variables / deprecated getAdhocFilters when this is empty/undefined
+  // (issue #506). Omitted -> resolved from variables as before.
+  adHocFilters?: AdHocFilter[] | null
 ): BuiltCubeQuery {
   const normalizedQuery = normalizeCubeQuery(query, {
     datasourceName: datasource.name,
     datasourceUid: datasource.uid,
     mapOperator: (operator) => datasource.mapOperator(operator),
     metadata: metadata ?? datasource.getCachedMetadata() ?? undefined,
+    adHocFilters,
   });
 
   const droppedAdHocFilters = normalizedQuery.droppedAdHocFilters ?? [];


### PR DESCRIPTION
Fixes #127. Implements #506 (editor-side follow-up to #500 / #307).

## What

The query editor's **SQL preview** now sources AdHoc filters from the editor's `props.data?.request?.filters` (Torkel's [supported editor path](https://github.com/grafana/grafana/pull/75552#issuecomment-3897315211)) as the **primary** source, so the preview reflects exactly what the last query executed with — instead of re-deriving from `getTemplateSrv().getVariables()`. This completes the migration off the deprecated `getAdhocFilters()` on the editor side too.

**Layered precedence** (mirrors the runtime `resolveAdHocFilters`):
1. `props.data.request.filters` — post-run, canonical (matches execution exactly, incl. request-level / scenes-injected filters)
2. `getTemplateSrv().getVariables()` adhoc vars — immediate / pre-run state
3. deprecated `getAdhocFilters()` — older Grafana only

## The gotcha (handled)

`data.request.filters` is only populated **after** a query runs. On first open / pre-run it's empty/undefined, so a pure `request.filters` preview would show no AdHoc `WHERE` until the query runs once. `resolveAdHocFilters` therefore **falls back to `getVariables()`** for the pre-run state, keeping the preview's AdHoc `WHERE` visible before the first execution. Documented in code and covered by a test.

## Changes (editor/preview only — reuses #500's plumbing)

- **`QueryEditor.tsx`** — threads `props.data?.request?.filters` into `useCubeQueryJson` (both the visual and unsupported/JSON editor modes). `useCubeQueryJson` passes it as the explicit `filters` to `buildCubeQueryJson` and keys the SQL-preview `useMemo` on the **resolved** filters, so the preview refreshes when the applied filters change.
- **`buildCubeQuery.ts`** — `buildCubeQueryJson` gains an optional `adHocFilters` arg, forwarded to `normalizeCubeQuery` (which already owns the precedence via `resolveAdHocFilters`).

The **runtime query path** (`applyTemplateVariables`) and the **`getTagValues`** path are unchanged — this is editor/preview-only, no regression to execution or view-scoping.

## Cube SDK parity

No change to Cube request/transport semantics — this only changes *where the editor reads AdHoc filters from* for the preview. It aligns the preview's source with the runtime `DataQueryRequest.filters` wired in #500, so preview and execution can no longer drift.

## Tests (+6)

- `buildCubeQuery.test.ts`: precedence — `request.filters` wins over variables/deprecated; empty/undefined `request.filters` → `getVariables()`; neither → deprecated.
- `QueryEditor.test.tsx`: the preview sources AdHoc filters from `props.data.request.filters` and **refreshes** when they change (memo key); and the pre-run `data`-undefined case falls back to `getVariables()`.

## Verification (node 24.15.0 / npm 11.12.1)

- `npm run typecheck` ✅ · `npm run test:ci` ✅ 20 suites / **320** · `npm run lint` ✅ 0 errors (6 pre-existing warnings) · `npm run build` ✅

References #506, #507/#500, #307. Don't merge on my end — for the two-reviewer + Bugbot flow.
