### PR TITLE
ci: run plugin-validator only on pushes to main

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -42,8 +42,13 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      # Run plugin-validator in CI to catch issues before release
-      run-plugin-validator: true
+      # PoC: run plugin-validator only on pushes to main, not on every PR.
+      # The validator (docker pull + osv-scanner + analyzers) adds ~1.5 min to the
+      # required 'Test and build plugin' check, and a single flagged CVE anywhere in
+      # the lockfile turns EVERY open PR red (as happened with fast-uri CVE-2026-18446).
+      # Dependabot/Socket/renovate already surface CVEs on PRs; keep the validator as
+      # a release gate on main instead of a merge gate on PRs.
+      run-plugin-validator: ${{ github.event_name == 'push' }}
       plugin-validator-config-path: .plugin-validator.yaml
       # Skip the grafana-dev image in Playwright tests (image may be temporarily unavailable)
       run-playwright-with-skip-grafana-dev-image: true


### PR DESCRIPTION
## PoC: take plugin-validator off the PR critical path

### What
`run-plugin-validator: ${{ github.event_name == 'push' }}` - the validator still runs on every merge to main (and in CD), but no longer inside the required **CI / Test and build plugin** check on PRs.

### Why
- The validator step (docker pull + osv-scanner + analyzers) adds ~1.5 min to the required check on every PR.
- One flagged CVE in the lockfile turns **every open PR red**: fast-uri CVE-2026-18446 failed 7 of the last 15 CI runs (Aug 4-6) across unrelated PRs.
- Dependabot, Socket Security and renovate already surface CVEs on PRs, so the marginal signal on PRs is low; the meaningful gate is before release, which the main push (and CD pipeline) still provides.

If this PR's 'Test and build plugin' check goes green while main still carries the fast-uri CVE, that's the demonstration working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)