### PR TITLE
ci: add shadow-mode selective test execution prototype

### DIFF
--- a/.ci/test-selection.json
+++ b/.ci/test-selection.json
@@ -1,0 +1,58 @@
+{
+  "description": "Change-based test selection policy. Maps changed-file globs to test domains. Consumed by scripts/select-tests.mjs (see docs/selective-ci.md). Rules are evaluated top-down, first match wins; files matching no rule run the FULL suite (fail-safe). Domains: none (no test impact), frontend (feed file to jest --findRelatedTests), frontend-full (run entire jest suite), backend (run go test ./pkg/...), e2e (Playwright-affected; report-only while in shadow mode), full (run everything).",
+  "version": 1,
+  "rules": [
+    {
+      "reason": "Changes to the selection machinery itself must never be able to skip the tests that would catch a bad selector",
+      "match": [".ci/**", "scripts/**", ".github/**"],
+      "domains": ["full"]
+    },
+    {
+      "reason": "Documentation, images and repo metadata cannot change test outcomes",
+      "match": [
+        "docs/**",
+        "**/*.md",
+        "LICENSE",
+        "src/img/**",
+        ".gitignore",
+        ".vscode/**",
+        ".cursor/**",
+        "renovate.json",
+        "release-please-config.json",
+        ".release-please-manifest.json",
+        ".plugin-validator.yaml"
+      ],
+      "domains": ["none"]
+    },
+    {
+      "reason": "Frontend source: jest traces the dependency graph itself via --findRelatedTests; UI changes can also affect Playwright flows",
+      "match": ["src/**"],
+      "domains": ["frontend", "e2e"]
+    },
+    {
+      "reason": "Go backend: the whole suite builds and runs in seconds, so any backend change runs all of it; backend behavior is also exercised by e2e",
+      "match": ["pkg/**", "go.mod", "go.sum", "Magefile.go"],
+      "domains": ["backend", "e2e"]
+    },
+    {
+      "reason": "E2E-only surfaces: specs, Playwright config, and the provisioned test environment",
+      "match": ["tests/**", "playwright.config.ts", "provisioning/**", "docker-compose.yaml", "dev-environment/**"],
+      "domains": ["e2e"]
+    },
+    {
+      "reason": "Frontend toolchain/config: invalidates the jest dependency graph, so run the full frontend suite",
+      "match": [
+        "jest.config.js",
+        "jest-setup.js",
+        "tsconfig.json",
+        ".config/**",
+        "package.json",
+        "package-lock.json",
+        ".npmrc",
+        ".nvmrc",
+        "eslint.config.mjs"
+      ],
+      "domains": ["frontend-full", "e2e"]
+    }
+  ]
+}

--- a/.github/workflows/selective-tests.yml
+++ b/.github/workflows/selective-tests.yml
@@ -1,0 +1,68 @@
+# Selective Tests — shadow-mode prototype of change-based test selection.
+#
+# Runs on every PR *alongside* the full "Plugins - CI" pipeline, and runs
+# only the tests the diff can plausibly affect, as decided deterministically
+# by scripts/select-tests.mjs from the policy in .ci/test-selection.json.
+#
+# While in shadow mode this check is intentionally NOT a required check:
+# its job is to produce (a) a fast signal for developers and (b) evidence —
+# every run's job summary records what was selected, what was skipped, and
+# why, so selective results can be compared against the full suite before
+# anyone trusts selection as a merge gate.
+#
+# The full model, fail-safe rules, and rollout plan: docs/selective-ci.md
+name: Selective Tests (shadow)
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  selective-tests:
+    name: Selective tests (experimental, non-blocking)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Full history so the merge-base diff against the PR base is exact.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Self-test the selection engine
+        # The selector guards every other suite, so its own tests always run.
+        run: node --test scripts/select-tests.test.mjs
+
+      - name: Compute test plan from changed files
+        id: plan
+        run: node scripts/select-tests.mjs --base "origin/${GITHUB_BASE_REF}"
+
+      - name: Install npm dependencies
+        if: steps.plan.outputs.frontend != 'skip'
+        run: npm ci
+
+      - name: Frontend unit tests (related to changed files)
+        if: steps.plan.outputs.frontend == 'related'
+        run: tr '\n' '\0' < "${{ steps.plan.outputs.frontend_files_list }}" | xargs -0 npx jest --passWithNoTests --maxWorkers 4 --findRelatedTests
+
+      - name: Frontend unit tests (full suite)
+        if: steps.plan.outputs.frontend == 'full'
+        run: npm run test:ci
+
+      - name: Backend tests (full go suite)
+        if: steps.plan.outputs.backend == 'run'
+        # No setup-go: the preinstalled toolchain auto-downloads the version
+        # pinned in go.mod (GOTOOLCHAIN=auto). The whole backend suite builds
+        # and runs in seconds, so per-package selection isn't worth it here.
+        # Scoped to ./pkg/... so vendored Go files under node_modules are
+        # never swept in when npm ci ran earlier in the job.
+        run: go test ./pkg/...

--- a/docs/selective-ci.md
+++ b/docs/selective-ci.md
@@ -1,0 +1,105 @@
+# Selective CI (shadow-mode prototype)
+
+This repo carries a prototype of **change-based test selection**: on every
+pull request, the `Selective Tests (shadow)` workflow inspects the diff,
+decides deterministically which test suites the change can plausibly affect,
+runs only those, and publishes an audit trail of every decision to the job
+summary. The full **Plugins - CI** pipeline continues to run unchanged on
+every PR and on every push to `main` — selection is a _shadow_, not a gate.
+
+It is also deliberately a small-scale testbed for a bigger idea: the same
+machinery, pointed at a repo where tests dominate CI wall-clock (this repo's
+tests do not — see [What this does and doesn't buy](#what-this-does-and-doesnt-buy-here)),
+is the on-ramp to selective CI for much larger codebases, with
+[yono](https://github.com/grafana/yono) overlays maintaining the policy.
+See yono's `docs/guides/test-selection.md` for that half of the design.
+
+## How it works
+
+Three pieces, all in this repo:
+
+| Piece    | File                                                                                | Role                                                                                                                                              |
+| -------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Policy   | [`.ci/test-selection.json`](../.ci/test-selection.json)                             | ~6 rules mapping path globs → test domains. The only hand-maintained artifact.                                                                    |
+| Engine   | [`scripts/select-tests.mjs`](../scripts/select-tests.mjs)                           | Classifies the diff against the policy, emits the plan + audit trail. Dependency-free, unit-tested (`node --test scripts/select-tests.test.mjs`). |
+| Workflow | [`.github/workflows/selective-tests.yml`](../.github/workflows/selective-tests.yml) | Runs the plan on PRs. Non-required check while in shadow mode.                                                                                    |
+
+The plan has three axes:
+
+- **Frontend (jest)** — the policy only decides _whether_ frontend tests run;
+  _which_ tests run is derived from the real module dependency graph by
+  `jest --findRelatedTests <changed files>`. There is no hand-written
+  file→test map to rot. Toolchain-level changes (lockfile, jest config,
+  `.config/`) escalate to the full jest suite because they invalidate the
+  dependency graph itself.
+- **Backend (go)** — any backend-affecting change runs `go test ./pkg/...`.
+  The entire Go suite builds and runs in seconds here, so per-package
+  selection via the import graph (the right answer at
+  grafana/grafana scale) would add complexity for no saving.
+- **E2E (Playwright)** — report-only: the plan records whether the change
+  is e2e-affecting, but Playwright still runs only in the full pipeline.
+  This is where the real wall-clock lives (five Grafana versions × image
+  pull + boot), and the lever there is slimming the PR-time version matrix
+  in the shared `plugin-ci-workflows` pipeline — a follow-up, not this
+  prototype.
+
+## Fail-safe rules
+
+Selection can only err toward running **more** tests, never fewer:
+
+1. A changed file matching **no policy rule** → full run of everything.
+2. Changes to the selection machinery itself (`.ci/`, `scripts/`,
+   `.github/`) → full run of everything.
+3. A changed frontend file that no longer exists (delete/rename) → full
+   jest suite, because its dependents can't be traced.
+4. Any selector error (unreadable policy, git failure) → full-run plan and
+   a green step, with the failure reason printed in the summary. The
+   selector must never be the reason CI blocks a PR.
+
+## Auditability
+
+Every run writes to the GitHub job summary: the plan, and a per-file table
+of _file → matched rule → domains_. When (not if) selection makes a call a
+human disagrees with, the artifact to fix is a visible, versioned rule —
+not a model's judgment. This is deliberate: the design keeps an LLM off the
+critical path (deterministic machinery decides per-PR) and reserves it for
+_maintaining_ the policy (see the yono overlay guide).
+
+## Rollout plan
+
+1. **Shadow (now).** Non-required check. Collect evidence: selective
+   outcome vs full-suite outcome per PR. The metric that matters is
+   _escapes_ — PRs where selection skipped a suite the full run failed.
+   Target: zero over a meaningful sample.
+2. **Gate.** Make `Selective Tests` a required check; keep the full suite
+   required too (no time saved yet, but the gate is proven under load).
+3. **Selective pre-merge.** Drop the full suite pre-merge: full pipeline
+   runs on push to `main` (it already does), selective runs on PRs. A
+   post-merge failure on `main` that a skipped test would have caught is
+   the signal to tighten the policy — and the event a yono overlay reacts
+   to automatically.
+4. **E2E matrix.** Separately: reduce the PR-time Playwright matrix (e.g.
+   oldest + newest supported Grafana) via `plugin-ci-workflows` inputs,
+   full matrix post-merge.
+
+## What this does and doesn't buy here
+
+Measured on a recent green run of Plugins - CI (~10m46s wall-clock): actual
+test execution is under ~2.5 minutes total — frontend test+build 45s,
+backend test+build 12s, and five parallel ~21s Playwright suites wrapped in
+~2–3 minutes each of runner queueing, Grafana image pulls, and setup. So in
+this repo, selection buys a fast (~1–2 min) developer signal and, at stage
+3, roughly a minute of required-check latency on docs/single-domain PRs.
+The mechanism, the audit trail, and the rollout ladder are the deliverable;
+the big wins belong to repos where the test-execution term dominates.
+
+## Maintenance
+
+The policy is a handful of rules over top-level directories and changes
+only when the repo's shape changes (a new top-level dir, a new toolchain
+file). Everything fine-grained is derived per-run from the actual
+dependency graph. Unrecognized paths fail safe to a full run, so a stale
+policy degrades to "runs too much", never "skips too much". The yono
+`test-selection` overlay (see yono repo) closes the loop long-term:
+it watches CI events, audits escapes and over-selection, and proposes
+policy updates as reviewable PRs.

--- a/scripts/select-tests.mjs
+++ b/scripts/select-tests.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Change-based test selection engine (shadow-mode prototype).
+ *
+ * Reads the set of files changed by a PR, classifies each file against the
+ * policy in .ci/test-selection.json, and emits a test plan:
+ *
+ *   frontend: "related" (jest --findRelatedTests <files>) | "full" | "skip"
+ *   backend:  "run" (go test ./pkg/...) | "skip"
+ *   e2e:      affected true/false (report-only while in shadow mode)
+ *
+ * Design constraints (see docs/selective-ci.md):
+ *  - Deterministic: the same diff always yields the same plan.
+ *  - Fail-safe: anything unrecognized, any error reading the diff or the
+ *    policy, and any deleted/renamed frontend file escalates toward running
+ *    MORE tests, never fewer. Selection failures produce a full-run plan
+ *    with exit code 0 rather than a red check.
+ *  - Auditable: every per-file decision (file -> matched glob -> domains) is
+ *    written to the GitHub job summary.
+ *
+ * Usage:
+ *   node scripts/select-tests.mjs --base origin/main
+ *   node scripts/select-tests.mjs --files-from changed.txt   # for testing
+ */
+
+import { readFileSync, writeFileSync, existsSync, appendFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Convert a policy glob to an anchored RegExp.
+ * Supported syntax: "**" (any path, crossing "/"), "*" (within one path
+ * segment), "?" (single non-"/" character). "**\/" also matches zero
+ * directories, so "**\/*.md" matches "README.md".
+ */
+export function globToRegExp(glob) {
+  let re = '';
+  let i = 0;
+  while (i < glob.length) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        if (glob[i + 2] === '/') {
+          re += '(?:.*/)?';
+          i += 3;
+        } else {
+          re += '.*';
+          i += 2;
+        }
+      } else {
+        re += '[^/]*';
+        i += 1;
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+      i += 1;
+    } else {
+      re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+      i += 1;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/** First-match-wins classification of one file against the policy rules. */
+export function classifyFile(file, policy) {
+  for (const rule of policy.rules) {
+    for (const glob of rule.match) {
+      if (globToRegExp(glob).test(file)) {
+        return { file, glob, domains: rule.domains, reason: rule.reason ?? '' };
+      }
+    }
+  }
+  // Fail-safe: a file the policy does not recognize runs everything.
+  return { file, glob: null, domains: ['full'], reason: 'no rule matched (fail-safe default)' };
+}
+
+/**
+ * Build the test plan for a set of changed files.
+ * `fileExists` is injectable for tests; the real caller passes fs.existsSync
+ * so that deleted/renamed frontend files (whose dependents jest can no
+ * longer trace) escalate the frontend run to "full".
+ */
+export function buildPlan(changedFiles, policy, fileExists = () => true) {
+  const decisions = changedFiles.map((f) => classifyFile(f, policy));
+
+  const has = (domain) => decisions.some((d) => d.domains.includes(domain));
+  const full = has('full');
+
+  let frontend = 'skip';
+  let frontendFiles = [];
+  if (full || has('frontend-full')) {
+    frontend = 'full';
+  } else if (has('frontend')) {
+    frontendFiles = decisions.filter((d) => d.domains.includes('frontend')).map((d) => d.file);
+    if (frontendFiles.every((f) => fileExists(f))) {
+      frontend = 'related';
+    } else {
+      // A deleted source file's dependents cannot be found via
+      // --findRelatedTests, so widen to the full frontend suite.
+      frontend = 'full';
+      frontendFiles = [];
+    }
+  }
+
+  const backend = full || has('backend') ? 'run' : 'skip';
+  const e2e = full || has('e2e');
+
+  return { frontend, frontendFiles, backend, e2e, full, decisions };
+}
+
+function changedFilesFromGit(baseRef) {
+  const out = execFileSync('git', ['diff', '--name-only', '--no-renames', `${baseRef}...HEAD`], { encoding: 'utf8' });
+  return out.split('\n').filter(Boolean);
+}
+
+function fullRunPlan(reason) {
+  return {
+    frontend: 'full',
+    frontendFiles: [],
+    backend: 'run',
+    e2e: true,
+    full: true,
+    decisions: [],
+    failSafe: reason,
+  };
+}
+
+function writeGithubOutputs(plan, listFile) {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  appendFileSync(
+    out,
+    [
+      `frontend=${plan.frontend}`,
+      `backend=${plan.backend}`,
+      `e2e_affected=${plan.e2e}`,
+      `frontend_files_list=${listFile ?? ''}`,
+      '',
+    ].join('\n')
+  );
+}
+
+function writeSummary(plan, changedFiles) {
+  const lines = [];
+  lines.push('## Selective test plan (shadow mode)');
+  lines.push('');
+  if (plan.failSafe) {
+    lines.push(`> ⚠️ Fail-safe triggered — running everything. Reason: ${plan.failSafe}`);
+    lines.push('');
+  }
+  lines.push('| Suite | Decision |');
+  lines.push('|---|---|');
+  const frontendLabel =
+    plan.frontend === 'related'
+      ? `related tests only (${plan.frontendFiles.length} changed source file(s) → \`jest --findRelatedTests\`)`
+      : plan.frontend;
+  lines.push(`| Frontend (jest) | ${frontendLabel} |`);
+  lines.push(`| Backend (go test ./pkg/...) | ${plan.backend} |`);
+  lines.push(
+    `| E2E (Playwright) | ${plan.e2e ? 'affected — full CI e2e matrix applies' : 'not affected by this change'} |`
+  );
+  lines.push('');
+  lines.push(`${changedFiles.length} changed file(s). Per-file decisions:`);
+  lines.push('');
+  lines.push('<details><summary>Audit trail</summary>');
+  lines.push('');
+  lines.push('| File | Matched rule | Domains |');
+  lines.push('|---|---|---|');
+  for (const d of plan.decisions) {
+    lines.push(`| \`${d.file}\` | \`${d.glob ?? '(none)'}\` | ${d.domains.join(', ') || 'none'} |`);
+  }
+  lines.push('');
+  lines.push('</details>');
+  lines.push('');
+  lines.push(
+    'This check is a non-blocking shadow of the full **Plugins - CI** pipeline. ' +
+      'See `docs/selective-ci.md` for the model, fail-safe rules, and rollout plan.'
+  );
+  const text = lines.join('\n') + '\n';
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, text);
+  }
+  return text;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const getArg = (name) => {
+    const i = args.indexOf(name);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const baseRef = getArg('--base');
+  const filesFrom = getArg('--files-from');
+  const policyPath = getArg('--policy') ?? '.ci/test-selection.json';
+
+  if (!baseRef && !filesFrom) {
+    console.error('usage: select-tests.mjs --base <ref> | --files-from <path> [--policy <path>]');
+    process.exit(1);
+  }
+
+  let plan;
+  let changedFiles = [];
+  try {
+    const policy = JSON.parse(readFileSync(policyPath, 'utf8'));
+    changedFiles = filesFrom
+      ? readFileSync(filesFrom, 'utf8').split('\n').filter(Boolean)
+      : changedFilesFromGit(baseRef);
+    plan = buildPlan(changedFiles, policy, existsSync);
+  } catch (err) {
+    // Selection must never be the reason CI goes red or tests get skipped.
+    plan = fullRunPlan(`selector error: ${err.message}`);
+  }
+
+  let listFile;
+  if (plan.frontend === 'related' && plan.frontendFiles.length > 0) {
+    listFile = path.join(process.env.RUNNER_TEMP ?? tmpdir(), 'selective-tests-frontend-files.txt');
+    writeFileSync(listFile, plan.frontendFiles.join('\n') + '\n');
+  }
+
+  writeGithubOutputs(plan, listFile);
+  const summary = writeSummary(plan, changedFiles);
+  console.log(summary);
+  console.log(JSON.stringify({ ...plan, decisions: undefined }, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/select-tests.mjs
+++ b/scripts/select-tests.mjs
@@ -131,7 +131,9 @@ function fullRunPlan(reason) {
 
 function writeGithubOutputs(plan, listFile) {
   const out = process.env.GITHUB_OUTPUT;
-  if (!out) return;
+  if (!out) {
+    return;
+  }
   appendFileSync(
     out,
     [

--- a/scripts/select-tests.test.mjs
+++ b/scripts/select-tests.test.mjs
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { globToRegExp, classifyFile, buildPlan } from './select-tests.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const policy = JSON.parse(readFileSync(path.join(repoRoot, '.ci', 'test-selection.json'), 'utf8'));
+
+test('globToRegExp semantics', () => {
+  assert.equal(globToRegExp('src/**').test('src/utils/buildCubeQuery.ts'), true);
+  assert.equal(globToRegExp('src/**').test('pkg/plugin/query.go'), false);
+  assert.equal(globToRegExp('**/*.md').test('README.md'), true);
+  assert.equal(globToRegExp('**/*.md').test('docs/a/b.md'), true);
+  assert.equal(globToRegExp('**/*.md').test('src/datasource.ts'), false);
+  assert.equal(globToRegExp('*.md').test('docs/a.md'), false);
+  assert.equal(globToRegExp('go.???').test('go.sum'), true);
+  assert.equal(globToRegExp('go.???').test('go.mod/x'), false);
+  // regex metacharacters in path names must be treated literally
+  assert.equal(globToRegExp('a+b/**').test('a+b/c.ts'), true);
+  assert.equal(globToRegExp('a+b/**').test('aab/c.ts'), false);
+});
+
+test('docs-only change skips every suite', () => {
+  const plan = buildPlan(['README.md', 'docs/selective-ci.md', 'src/img/logo.svg'], policy);
+  assert.equal(plan.frontend, 'skip');
+  assert.equal(plan.backend, 'skip');
+  assert.equal(plan.e2e, false);
+});
+
+test('frontend source change selects related jest tests and flags e2e', () => {
+  const plan = buildPlan(['src/utils/buildCubeQuery.ts'], policy);
+  assert.equal(plan.frontend, 'related');
+  assert.deepEqual(plan.frontendFiles, ['src/utils/buildCubeQuery.ts']);
+  assert.equal(plan.backend, 'skip');
+  assert.equal(plan.e2e, true);
+});
+
+test('backend change runs full go suite, skips jest', () => {
+  const plan = buildPlan(['pkg/plugin/query.go', 'go.sum'], policy);
+  assert.equal(plan.backend, 'run');
+  assert.equal(plan.frontend, 'skip');
+  assert.equal(plan.e2e, true);
+});
+
+test('frontend toolchain change escalates to full jest suite', () => {
+  const plan = buildPlan(['package-lock.json'], policy);
+  assert.equal(plan.frontend, 'full');
+  assert.equal(plan.backend, 'skip');
+});
+
+test('workflow/selection-infra change runs everything', () => {
+  for (const f of ['.github/workflows/push.yaml', '.ci/test-selection.json', 'scripts/select-tests.mjs']) {
+    const plan = buildPlan([f], policy);
+    assert.equal(plan.full, true, f);
+    assert.equal(plan.frontend, 'full', f);
+    assert.equal(plan.backend, 'run', f);
+    assert.equal(plan.e2e, true, f);
+  }
+});
+
+test('unrecognized file falls back to full run (fail-safe)', () => {
+  const plan = buildPlan(['mystery-new-dir/thing.xyz'], policy);
+  assert.equal(plan.full, true);
+  const d = classifyFile('mystery-new-dir/thing.xyz', policy);
+  assert.equal(d.glob, null);
+});
+
+test('deleted frontend file widens jest run to full (fail-safe)', () => {
+  const exists = (f) => f !== 'src/utils/removed.ts';
+  const plan = buildPlan(['src/utils/removed.ts'], policy, exists);
+  assert.equal(plan.frontend, 'full');
+  assert.deepEqual(plan.frontendFiles, []);
+});
+
+test('mixed frontend and backend change runs both, selectively where possible', () => {
+  const plan = buildPlan(['src/datasource.ts', 'pkg/plugin/datasource.go'], policy);
+  assert.equal(plan.frontend, 'related');
+  assert.equal(plan.backend, 'run');
+  assert.equal(plan.e2e, true);
+});
+
+test('e2e-only change touches neither unit suite', () => {
+  const plan = buildPlan(['tests/queryEditor.spec.ts', 'playwright.config.ts'], policy);
+  assert.equal(plan.frontend, 'skip');
+  assert.equal(plan.backend, 'skip');
+  assert.equal(plan.e2e, true);
+});


### PR DESCRIPTION
## What

A prototype of **change-based test selection**, running in shadow mode: a new non-required PR workflow that deterministically decides which test suites the diff can plausibly affect, runs only those, and writes a per-file audit trail (file → matched rule → domains) to the job summary. The existing **Plugins - CI** pipeline is untouched and still runs everything.

Three pieces:

- **`.ci/test-selection.json`** — six rules mapping path globs to test domains. The only hand-maintained artifact.
- **`scripts/select-tests.mjs`** — dependency-free selection engine (unit-tested via `node --test scripts/select-tests.test.mjs`, which the workflow also runs on every PR). Which jest tests run is derived from the module graph via `jest --findRelatedTests` — there is no hand-written file→test map to rot.
- **`.github/workflows/selective-tests.yml`** — runs the plan on PRs as a non-blocking check.

Full model, measured CI timings, and the four-rung rollout ladder (shadow → required → selective-pre-merge/full-post-merge → e2e matrix reduction): `docs/selective-ci.md`.

## Why

On a recent green run of Plugins - CI (~10m46s wall clock), actual test execution was under ~2.5 min — backend test+build is 12s, and each Playwright suite runs ~21s inside ~2–3 min of setup. Selection can't fix the provisioning-dominated pipeline, but it gives a fast (~1–2 min) developer signal, and this repo is a deliberately small proving ground for the mechanism before pointing it at repos where test execution *does* dominate.

## Fail-safe design

Selection only ever errs toward running more: unmatched paths → full run; changes to the selection machinery itself → full run; deleted/renamed frontend sources → full jest suite; selector errors → full-run plan with the reason in the summary. (This PR touches `.github/`, `.ci/`, and `scripts/`, so its own selective check should demonstrate the full-run fail-safe path.)

## Verification

- Engine unit tests: 10/10 green.
- End-to-end locally: a one-file change to `src/utils/buildCubeQuery.ts` selects 2 of 20 jest suites (45 of 314 tests, ~7s); `go test ./pkg/...` green (scoped to `./pkg/...` because `./...` sweeps a stray Go package inside `node_modules`).
- Prettier/lint clean; workflow reuses the repo's existing pinned action SHAs; no new dependencies.

## Companion

The policy-maintenance half (a yono overlay that audits CI outcomes for escapes and proposes policy tightening as PRs) is proposed in grafana/yono#497, together with the openspec change for the GitHub Actions CI ingest that would feed it events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxZNNjCR4ctc3NKkNb3F6F