### PR TITLE
ci: restore full Grafana matrix in CD and add scheduled e2e canary

### DIFF
--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -1,0 +1,36 @@
+# Scheduled e2e canary: runs Playwright against the FULL supported Grafana version
+# range (from plugin.json's grafanaDependency) PLUS the grafana-nightly image.
+#
+# PR CI (push.yaml) intentionally tests a single Grafana version to keep the
+# iteration loop fast. This canary is the early-warning counterpart: it catches
+# breakage in new/upcoming Grafana versions without blocking anyone's PR.
+# Failures notify the last committer of this file via GitHub's scheduled-workflow
+# failure notifications.
+#
+# Runs on a schedule (not on PRs), and can be triggered manually for debugging.
+
+name: e2e canary (full Grafana matrix + nightly)
+
+on:
+  schedule:
+    # Weekdays at 05:17 UTC, before the working day starts.
+    - cron: '17 5 * * 1-5'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  ci:
+    name: CI
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.2.0
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      # No grafana-dependency override: the version resolver reads
+      # plugin.json's grafanaDependency and expands to every supported minor.
+      # No skip-grafana-nightly-image: the nightly image IS included here
+      # (unlike push.yaml/publish.yaml) - that's the point of the canary.
+      # plugin-validator is deliberately not enabled: CVE/validator signal
+      # belongs to the main push and CD runs, not the version canary.
+      run-playwright-with-version-resolver-type: plugin-grafana-dependency

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,8 +50,9 @@ jobs:
 
       # Skip the grafana-nightly image in Playwright E2E tests (image may be temporarily unavailable)
       run-playwright-with-skip-grafana-nightly-image: true
-      # Keep CD's e2e matrix in sync with CI (single reliable version, see push.yaml)
-      run-playwright-with-grafana-dependency: '~12.2.0'
+      # Unlike PR CI (single version, see push.yaml), CD runs e2e against the FULL
+      # supported version range from plugin.json's grafanaDependency: releases are
+      # infrequent, so full coverage before publishing is worth the extra ~3 min.
 
       # TODO: add here any other CI custom inputs you may need. You most likely also have to add the same options to push.yaml:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs


### PR DESCRIPTION
Follow-up to #537, completing the e2e strategy:

### 1. CD runs the full matrix again (`publish.yaml`)
Drops the single-version pin from CD. Releases are infrequent and manual, so running e2e against every supported minor from `grafanaDependency` (~3 extra min) is the right trade before publishing.

### 2. New scheduled e2e canary (`e2e-canary.yml`)
Weekdays at 05:17 UTC (plus `workflow_dispatch` for manual runs), calls the same shared CI workflow with:
- the **full supported version range**, and
- the **grafana-nightly image included** (it stays skipped in PR CI and CD),
so breakage in new/upcoming Grafana versions surfaces early without blocking anyone's PR. On `schedule` the shared workflow treats the context as untrusted: unsigned build, no Vault/GCS - it purely builds and runs e2e. Failures notify via GitHub's scheduled-workflow notifications (last committer of the file).

Net layering:
| Where | Versions | Purpose |
|---|---|---|
| PR CI | 1 (12.2.x) | fast iteration loop |
| CD | all released supported | release gate |
| Canary | all + nightly | early warning |

🤖 Generated with [Claude Code](https://claude.com/claude-code)