### PR TITLE
fix(deps): apply js-yaml override to @istanbuljs/load-nyc-config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2114,16 +2114,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2136,20 +2126,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -14578,13 +14554,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/sql-formatter": {
       "version": "15.8.2",

--- a/package.json
+++ b/package.json
@@ -97,9 +97,6 @@
     "ws": "8.21.3",
     "prismjs": "1.30.0",
     "fast-uri": "4.1.2",
-    "js-yaml": "5.3.0",
-    "@istanbuljs/load-nyc-config": {
-      "js-yaml": "5.3.0"
-    }
+    "js-yaml": "5.3.0"
   }
 }


### PR DESCRIPTION
## What

Follow-up to #550, which Cursor Bugbot flagged (medium severity) before it was merged.

#550 bumped both js-yaml overrides in `package.json` from `4.3.1` / `3.15.1` to `5.3.0`, but Renovate's lockfile edit only rewrote the top-level `node_modules/js-yaml` entry. `package-lock.json` kept nesting `js-yaml@3.15.1` under `@istanbuljs/load-nyc-config`, so the declared override for that path had no effect - `npm ci` on `main` installs `3.15.1` there today.

## Why npm did not self-heal

Worth recording, because it is not obvious and `npm install` looks like it should have fixed this:

- npm does not write `overrides` into the lockfile at all, so it cannot detect that they changed.
- The locked `3.15.1` still satisfies load-nyc-config's declared `^3.13.1` range, so npm leaves the node alone.

`npm install --package-lock-only` was a no-op on the merged state. The stale subtree had to be dropped before regenerating.

To be clear about impact: Bugbot's claim that installs "can fail" is not right - `npm ci` succeeds on `main`. The real problem is quieter: the override silently does nothing, and the lockfile diverges from what `package.json` declares.

## Changes

- `package-lock.json`: drop the stale `@istanbuljs/load-nyc-config` nested subtree and re-resolve. load-nyc-config now resolves js-yaml from the hoisted top-level `5.3.0`, which also removes the transitive `argparse@1.0.10` and `sprintf-js` copies.
- `package.json`: remove the nested `@istanbuljs/load-nyc-config` override entirely.

On that second point - with both entries on `5.3.0` the nested override was a no-op that Renovate would keep bumping in lockstep, reintroducing exactly this drift on every future js-yaml release. Removing it deletes the mechanism rather than just the symptom. Its original purpose (holding load-nyc-config on the 3.x line while the top level moved to 4.3.1, added in #535) no longer exists. Removing it leaves the lockfile byte-identical, which confirms it was redundant.

## Testing

All from a clean `rm -rf node_modules && npm ci`:

- No nested `js-yaml` remains; load-nyc-config resolves `5.3.0`.
- `loadNycConfig()` parses a real `.nycrc.yaml` end-to-end under v5. This is load-nyc-config's only js-yaml usage (`require('js-yaml').load()`), and v5 still ships a CJS entry point despite the TypeScript rewrite.
- `npm run build` - webpack compiles clean.
- `npm run test:ci` - 20 suites / 314 tests pass.
- `npm run typecheck` - clean.
- `npm run lint` - 0 errors (6 pre-existing `MultiSelect` deprecation warnings, untouched here).

The build and lint runs matter beyond the usual smoke check: they exercise the three other js-yaml consumers - `@eslint/eslintrc`, fork-ts-checker's `cosmiconfig`, and `webpack-cli`.

## One thing to flag

Not changed here, since #550 already made and merged this call: the global pin forces `5.3.0` onto `@eslint/eslintrc` and `cosmiconfig`, both of which declare `^4.x`. Only `webpack-cli` formally accepts `^5`. Everything passes, but that is semver-forced rather than semver-blessed - worth knowing if something odd surfaces in lint or build later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
