### PR TITLE
ci: fail the drift check when the lockfile ignores a declared override

### DIFF
--- a/.github/scripts/check-lockfile-overrides.mjs
+++ b/.github/scripts/check-lockfile-overrides.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Assert that every `overrides` entry in package.json is actually reflected in
+ * package-lock.json.
+ *
+ * `npm ci` cannot catch this. npm never records `overrides` in the lockfile, so
+ * it has nothing to compare against, and a stale nested entry whose original
+ * range still matches is left untouched. That let PR #550 merge green with a
+ * declared js-yaml override silently unapplied: package.json pinned
+ * @istanbuljs/load-nyc-config's js-yaml to 5.3.0 while the lockfile kept
+ * resolving 3.15.1 (fixed in #563).
+ *
+ * Renovate edits lockfiles surgically rather than regenerating them, so it can
+ * bump an override in package.json while rewriting only the top-level lockfile
+ * entry. Expect this check to fire on that, and see the remediation it prints -
+ * plain `npm install` will not fix it.
+ */
+import { readFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const lock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
+
+// Flat overrides ("js-yaml": "5.3.0") apply to every instance in the tree.
+// Nested overrides ({"parent": {"child": "..."}}) apply only under that parent.
+const flat = new Map();
+const nested = [];
+for (const [name, value] of Object.entries(pkg.overrides ?? {})) {
+  if (typeof value === 'string') {
+    flat.set(name, value);
+  } else {
+    for (const [child, version] of Object.entries(value)) {
+      if (typeof version === 'string') {
+        nested.push({ parent: name, child, version });
+      }
+    }
+  }
+}
+
+const MARKER = 'node_modules/';
+const problems = [];
+
+for (const [path, meta] of Object.entries(lock.packages ?? {})) {
+  if (!path || !meta.version) {
+    continue;
+  }
+  const name = path.slice(path.lastIndexOf(MARKER) + MARKER.length);
+
+  // npm applies the most specific matching rule, so a nested override for this
+  // exact path wins over a flat override of the same package name.
+  const rule = nested.find((n) => path === `node_modules/${n.parent}/node_modules/${n.child}`);
+  const expected = rule ? rule.version : flat.get(name);
+  if (!expected || meta.version === expected) {
+    continue;
+  }
+
+  const source = rule ? `nested override under ${rule.parent}` : 'override';
+  problems.push(`${path}\n      locked ${meta.version}, ${source} declares ${expected}`);
+}
+
+if (problems.length > 0) {
+  console.error(`package-lock.json does not honour ${problems.length} declared override(s):\n`);
+  for (const problem of problems) {
+    console.error(`  - ${problem}\n`);
+  }
+  console.error('To fix: delete the offending entries from package-lock.json, then run');
+  console.error('`npm install --package-lock-only`. Plain `npm install` will NOT self-heal,');
+  console.error('because the locked version still satisfies the dependency range it came from.');
+  process.exit(1);
+}
+
+console.log(`All ${flat.size + nested.length} declared override(s) are honoured in package-lock.json.`);

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,6 +34,12 @@ jobs:
       - name: Install dependencies (fails if lockfile is out of sync)
         run: npm ci
 
+      # `npm ci` above only checks dependencies/devDependencies. npm never writes
+      # `overrides` into the lockfile, so an override can be bumped in package.json
+      # while the lockfile keeps resolving the old version - silently, as in #550.
+      - name: Check declared overrides are honoured by the lockfile
+        run: node .github/scripts/check-lockfile-overrides.mjs
+
   ci:
     name: CI
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v11.1.0


### PR DESCRIPTION
## What

Follow-up to #563. Teaches the required "Check for package-lock.json drift" job to catch the class of bug that slipped through in #550.

## Why the existing check missed it

The job is only `npm ci` ([push.yaml](https://github.com/grafana/grafana-cube-datasource/blob/main/.github/workflows/push.yaml)), which is structurally unable to detect `overrides` drift:

- npm never writes `overrides` into the lockfile, so `npm ci` has nothing to compare against - it only verifies `dependencies`/`devDependencies`.
- A stale nested entry whose original range still matches is left untouched.

Worth being precise about what happened on #550, since the obvious guess is wrong: the drift check **was** required, it **did** run, and it **passed** in 42s. Nothing was merged past a red check. The lockfile kept resolving `js-yaml@3.15.1` under `@istanbuljs/load-nyc-config` while `package.json` declared `5.3.0`, and no check anywhere objected.

This will recur. Renovate edits lockfiles surgically rather than regenerating them, so it can bump an override in `package.json` while rewriting only the top-level lockfile entry.

## Changes

- `.github/scripts/check-lockfile-overrides.mjs` - compares `package.json`'s `overrides` against every matching `package-lock.json` entry, and fails with the offending path, both versions, and the remediation.
- `.github/workflows/push.yaml` - one new step in the existing `check-lockfile-drift` job.

Adding it as a step in the already-required job means it becomes a required check with **no branch-protection change**.

## Cost

Effectively zero:

- It is a JSON parse. No network, no install, milliseconds.
- It reuses the existing job's checkout and Node setup, so no new job or runner.
- That job's median is ~39s (range 26-55s over the last 20 runs) and runs fully parallel to `CI / Test and build plugin` (~5m), which is the critical path. This adds no wall-clock.

## Testing

- Passes on current `main`: `All 8 declared override(s) are honoured in package-lock.json.`
- Fails on `08d6081` (the #550 merge) with the exact defect:

  ```
  package-lock.json does not honour 1 declared override(s):

    - node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml
        locked 3.15.1, nested override under @istanbuljs/load-nyc-config declares 5.3.0
  ```

- **Replayed across the last 25 commits of `main`**: clean on every one except `08d6081`. One true positive, zero false positives.
- `npm run lint` clean on the new script; the workflow YAML parses (validated with the repo's own js-yaml).

That replay was worth doing - it caught a real bug in my first version, which ignored that a nested override beats a flat one for the same path and so flagged 9 days of history as broken. The script now mirrors npm's most-specific-rule resolution.

## Limitations

- It compares **exact versions**. Every override in this repo is an exact pin, so this is sound today; a range override would need semver satisfaction instead.
- It catches the symptom, not the cause. It will not stop Renovate producing this drift, so expect it to fire on future major bumps of an overridden package and need a manual lockfile regeneration. That is the intent - fail loudly rather than merge silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
