### PR TITLE
ci: bump release.yml Go pin to 1.26.5 to match go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           policy_token: ${{ env.GRAFANA_ACCESS_POLICY_TOKEN }}
           attestation: true
-          go-version: '1.26.3'
+          go-version: '1.26.5'
           node-version: '24'
 
       - name: Publish release with CHANGELOG.md as body


### PR DESCRIPTION
## Summary
- `release.yml` pins `go-version: 1.26.3` while `go.mod` requires `>= 1.26.5`. The v0.6.4 GitHub release job failed immediately: `go.mod requires go >= 1.26.5 (running go 1.26.3; GOTOOLCHAIN=local)`.
- This input cannot be removed: `grafana/plugin-actions/build-plugin` defaults to Go 1.25, which would fail the same way.
- A `# renovate` comment on `go-version:` would not help — the Grafana preset only matches `*_VERSION` env vars. This is a one-line pin bump so the existing `v0.6.4` tag can be rebuilt after merge.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the failed [Release workflow for `v0.6.4`](https://github.com/grafana/grafana-cube-datasource/actions/runs/32474917013) (or push a no-op tag re-fire) and confirm signed artifacts attach to the GitHub release


Made with [Cursor](https://cursor.com)