### PR TITLE
docs: record #531 and #577 in the 0.6.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Changelog
 
-## [0.6.4](https://github.com/grafana/grafana-cube-datasource/compare/v0.6.3...v0.6.4) (2026-08-18)
+## [0.6.4](https://github.com/grafana/grafana-cube-datasource/compare/v0.6.3...v0.6.4) (2026-08-21)
 
 
 ### Bug Fixes
 
 * **adhoc:** drop AdHoc filters inapplicable to a query's Cube view ([#307](https://github.com/grafana/grafana-cube-datasource/issues/307)) ([#495](https://github.com/grafana/grafana-cube-datasource/issues/495)) ([dc4130d](https://github.com/grafana/grafana-cube-datasource/commit/dc4130dabc5e453d10d521f0f618966f6868d20c))
 * **adhoc:** partition getTagValues scoping filters + time dimension by view ([#498](https://github.com/grafana/grafana-cube-datasource/issues/498)) ([#499](https://github.com/grafana/grafana-cube-datasource/issues/499)) ([fe0ba7e](https://github.com/grafana/grafana-cube-datasource/commit/fe0ba7ec854062073952b9c1e26cac985ede27d6))
+* **adhoc:** treat scenes' match-all filter (`=~ .*`) as no-op instead of equals `'.*'` ([#531](https://github.com/grafana/grafana-cube-datasource/issues/531)) ([d4d3996](https://github.com/grafana/grafana-cube-datasource/commit/d4d39966312519c7deb2bae5573b97eefe2bb89b))
 * **adhoc:** wire AdHoc filters via request.filters ([#127](https://github.com/grafana/grafana-cube-datasource/issues/127)) + [#307](https://github.com/grafana/grafana-cube-datasource/issues/307) demo ([#507](https://github.com/grafana/grafana-cube-datasource/issues/507)) ([c45b7f3](https://github.com/grafana/grafana-cube-datasource/commit/c45b7f3ec01ff333e999e4e994792b6e42928dbb))
 * **deps:** apply js-yaml override to @istanbuljs/load-nyc-config ([#563](https://github.com/grafana/grafana-cube-datasource/issues/563)) ([7ca859c](https://github.com/grafana/grafana-cube-datasource/commit/7ca859cd9ded3f4634fade18c016312484824fa4))
 * **deps:** bump fast-uri to 3.1.5 to fix CVE-2026-18446 ([#535](https://github.com/grafana/grafana-cube-datasource/issues/535)) ([62151c5](https://github.com/grafana/grafana-cube-datasource/commit/62151c54dd68cf870f1633e81a494a0e570584a5))
+* **deps:** update dependency @grafana/plugin-ui to v0.17.4 ([#577](https://github.com/grafana/grafana-cube-datasource/issues/577)) ([7aa0888](https://github.com/grafana/grafana-cube-datasource/commit/7aa08880a6cb6f12736335ff6e655e216e2278c3))
 * **deps:** update grafana monorepo to v13.1.2 ([#544](https://github.com/grafana/grafana-cube-datasource/issues/544)) ([f53ba8f](https://github.com/grafana/grafana-cube-datasource/commit/f53ba8f4e87f5320b23aa4c56cfa37ae7975079e))
 * **deps:** update grafana monorepo to v13.1.3 ([#556](https://github.com/grafana/grafana-cube-datasource/issues/556)) ([8aedab8](https://github.com/grafana/grafana-cube-datasource/commit/8aedab8d9323f25cef7db8d4896271c29d0ff7cf))
 * **deps:** update module github.com/grafana/grafana-plugin-sdk-go to v0.295.0 ([#529](https://github.com/grafana/grafana-cube-datasource/issues/529)) ([a5adc40](https://github.com/grafana/grafana-cube-datasource/commit/a5adc40a6d4322f127e3411b9f4cf5725b2825bd))


### PR DESCRIPTION
## Summary
- v0.6.4 already shipped [#531](https://github.com/grafana/grafana-cube-datasource/pull/531) (match-all adhoc sentinel) and [#577](https://github.com/grafana/grafana-cube-datasource/pull/577) (`@grafana/plugin-ui` 0.17.4), but the stale release-please notes omitted them.
- This updates `CHANGELOG.md` to match the bits. The [GitHub release](https://github.com/grafana/grafana-cube-datasource/releases/tag/v0.6.4) notes are already updated.

## Test plan
- [ ] Confirm the 0.6.4 section lists #531 and #577
- [ ] Confirm this `docs:` commit does not open a 0.6.5 release-please PR


Made with [Cursor](https://cursor.com)