### PR TITLE
fix: treat scenes' all-value sentinel (=| $__all) as a no-op

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -171,6 +171,27 @@ describe('DataSource', () => {
       expect(result).toEqual(mockValues);
     });
 
+    // Same for the current All sentinel shape (`=| $__all`, scenes#1591).
+    it('should ignore the all-value sentinel when scoping value lookups', async () => {
+      mockGetResource.mockResolvedValue(['value1']);
+      const datasource = createDataSource();
+
+      const allValue = { key: 'orders.status', operator: '=|', value: '$__all', values: ['$__all'] };
+
+      await datasource.getTagValues({ key: 'orders.customer', filters: [allValue] });
+      expect(mockGetResource).toHaveBeenCalledWith('tag-values', { key: 'orders.customer', filters: undefined });
+
+      mockGetResource.mockClear();
+      await datasource.getTagValues({
+        key: 'orders.customer',
+        filters: [allValue, { key: 'orders.status', operator: '=', value: 'completed' }],
+      });
+      expect(mockGetResource).toHaveBeenCalledWith('tag-values', {
+        key: 'orders.customer',
+        filters: JSON.stringify([{ member: 'orders.status', operator: 'equals', values: ['completed'] }]),
+      });
+    });
+
     // Scenes' cleared pinned filter (`=~ .*`, shown as "All") means "restrict
     // nothing" — it must not scope value lookups (issue #530).
     it('should ignore scenes match-all sentinel filters (issue #530)', async () => {
@@ -728,6 +749,82 @@ describe('DataSource', () => {
         const datasource = createDataSource();
         // No explicit filters argument (older Grafana path).
         const result = datasource.applyTemplateVariables(query, {});
+
+        expect(result.filters).toBeUndefined();
+      });
+    });
+
+    // Runtime-level guarantee for scenes#1591: the All sentinel on the one-of
+    // operator (`=| $__all`) must never reach Cube. Scenes excludes it from
+    // DataQueryRequest.filters, so it arrives via the dashboard-variable fallback
+    // (issue #127) rather than the explicit list — that is the regression path.
+    describe('scenes all-value sentinel (scenes#1591)', () => {
+      const allValue = { key: 'orders.status', operator: '=|', value: '$__all', values: ['$__all'] };
+      const query = {
+        refId: 'A',
+        dimensions: ['orders.status'],
+        measures: ['orders.count'],
+      };
+
+      it('produces NO Cube filter when the variable fallback recovers a stripped sentinel', () => {
+        mockGetTemplateSrv.mockReturnValue({
+          replace: (str: string) => str,
+          getVariables: () => [{ type: 'adhoc', datasource: { uid: 'test-uid' }, filters: [allValue] }],
+          getAdhocFilters: () => [],
+        });
+
+        const datasource = createDataSource();
+        // Empty explicit list: scenes removed the sentinel before handing over.
+        const result = datasource.applyTemplateVariables(query, {}, []);
+
+        expect(result.filters).toBeUndefined();
+      });
+
+      it('produces NO Cube filter for a lone sentinel in the explicit list', () => {
+        mockGetTemplateSrv.mockReturnValue({
+          replace: (str: string) => str,
+          getVariables: () => [],
+          getAdhocFilters: () => [],
+        });
+
+        const datasource = createDataSource();
+        expect(datasource.applyTemplateVariables(query, {}, [allValue]).filters).toBeUndefined();
+      });
+
+      it('keeps only the real filter when mixed with a sentinel', () => {
+        mockGetTemplateSrv.mockReturnValue({
+          replace: (str: string) => str,
+          getVariables: () => [],
+          getAdhocFilters: () => [],
+        });
+
+        const datasource = createDataSource();
+        const result = datasource.applyTemplateVariables(query, {}, [
+          allValue,
+          { key: 'orders.region', operator: '=|', value: 'AMER', values: ['AMER', 'EMEA'] },
+        ]);
+
+        expect(result.filters).toEqual([
+          { member: 'orders.region', operator: Operator.Equals, values: ['AMER', 'EMEA'] },
+        ]);
+      });
+
+      it('produces NO Cube filter when every pinned filter is All (reported dashboard case)', () => {
+        const pinnedAll = ['ae_l1_territory', 'ae_l3_territory', 'ae_segment', 'ae_seller_type'].map((key) => ({
+          key: `sales_northern_lights.${key}`,
+          operator: '=|',
+          value: '$__all',
+          values: ['$__all'],
+        }));
+
+        mockGetTemplateSrv.mockReturnValue({
+          replace: (str: string) => str,
+          getVariables: () => [{ type: 'adhoc', datasource: { uid: 'test-uid' }, filters: pinnedAll }],
+          getAdhocFilters: () => [],
+        });
+
+        const datasource = createDataSource();
+        const result = datasource.applyTemplateVariables(query, {}, []);
 
         expect(result.filters).toBeUndefined();
       });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -125,8 +125,8 @@ export class DataSource extends DataSourceWithBackend<CubeQuery, CubeDataSourceO
     // Context time range Grafana passes to getTagValues since v10.3.
     timeRange?: TimeRange;
   }) {
-    // Scenes' match-all sentinel (`=~ .*`, a cleared pinned filter) means
-    // "restrict nothing" — drop it before scoping (issue #530).
+    // Scenes' match-all sentinels (`=| $__all` and the older `=~ .*`) mean
+    // "restrict nothing" — drop them before scoping (issue #530).
     const scopingCandidates = dropMatchAllFilters(options.filters ?? []);
 
     // Nothing to partition or scope (no scoping filters and no time range): skip

--- a/src/utils/adHocFilters.test.ts
+++ b/src/utils/adHocFilters.test.ts
@@ -97,6 +97,73 @@ describe('resolveAdHocFilters (issue #127)', () => {
   });
 });
 
+// Since grafana/scenes#1591 a pinned filter that restricts nothing carries the All
+// sentinel on the multi-value operator (`=| $__all`) rather than `=~ .*`. mapOperator
+// collapses `=|` to equals, so forwarding it asks Cube for `x equals '$__all'` — no
+// rows, while the pill reads "All".
+describe('all-value sentinel handling (scenes#1591)', () => {
+  const allValue = { key: 'orders.status', operator: '=|', value: '$__all', values: ['$__all'] };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setTemplateSrv({ variables: [], getAdhocFilters: () => [] });
+  });
+
+  it('isMatchAllFilter recognises the one-of All sentinel', () => {
+    expect(isMatchAllFilter(allValue)).toBe(true);
+    // value-only shape, as the default filters editor persists it
+    expect(isMatchAllFilter({ operator: '=|', value: '$__all' })).toBe(true);
+  });
+
+  it('only treats All as match-all on the one-of operator', () => {
+    // "not one of" never offers All (it would read as excluding everything), so a
+    // literal $__all there stays a real filter.
+    expect(isMatchAllFilter({ operator: '!=|', value: '$__all', values: ['$__all'] })).toBe(false);
+    expect(isMatchAllFilter({ operator: '=', value: '$__all' })).toBe(false);
+  });
+
+  it('preserves one-of filters with real values', () => {
+    const multiValue = { key: 'orders.region', operator: '=|', value: 'AMER', values: ['AMER', 'EMEA'] };
+    expect(isMatchAllFilter(multiValue)).toBe(false);
+    expect(resolveAdHocFilters(datasource, [multiValue, allValue])).toEqual([multiValue]);
+  });
+
+  it('treats All mixed with real values as match-all, matching scenes', () => {
+    // Scenes makes All exclusive in the combobox so this should not occur, but its
+    // own isMatchAllFilter uses .includes() — mirror that rather than diverge.
+    expect(isMatchAllFilter({ operator: '=|', value: 'AMER', values: ['AMER', '$__all'] })).toBe(true);
+  });
+
+  it('drops the sentinel from an explicit filters list', () => {
+    expect(resolveAdHocFilters(datasource, [allValue, filterA])).toEqual([filterA]);
+  });
+
+  it('drops the sentinel recovered from dashboard AdHoc variables', () => {
+    // The actual regression: scenes excludes the sentinel from
+    // DataQueryRequest.filters, so the explicit list arrives EMPTY and the
+    // variable fallback reads it straight back in.
+    setTemplateSrv({
+      variables: [{ type: 'adhoc', datasource: { uid: datasource.uid }, filters: [allValue, filterB] }],
+    });
+    expect(resolveAdHocFilters(datasource, [])).toEqual([filterB]);
+  });
+
+  it('yields no filters when every pinned filter is All', () => {
+    // The reported dashboard case: five pinned filters all set to All must mean
+    // "no restriction", not five filters that each match nothing.
+    const pinnedAll = ['ae_l1_territory', 'ae_l3_territory', 'ae_segment', 'ae_seller_type'].map((key) => ({
+      key: `sales_northern_lights.${key}`,
+      operator: '=|',
+      value: '$__all',
+      values: ['$__all'],
+    }));
+    setTemplateSrv({
+      variables: [{ type: 'adhoc', datasource: { uid: datasource.uid }, filters: pinnedAll }],
+    });
+    expect(resolveAdHocFilters(datasource, [])).toEqual([]);
+  });
+});
+
 // Scenes rewrites a cleared dashboard-origin (pinned) filter to its match-all
 // sentinel (`=~ .*`, displayed "All") and passes it to queries. mapOperator
 // collapses =~ to equals, so forwarding it would mean `x equals '.*'` — the

--- a/src/utils/adHocFilters.ts
+++ b/src/utils/adHocFilters.ts
@@ -8,27 +8,50 @@ import { getTemplateSrv } from '@grafana/runtime';
  */
 export type AdHocFilter = AdHocVariableFilter;
 
+/** Scenes' multi-value "one of" operator. */
+const ONE_OF_OPERATOR = '=|';
+
 /**
- * Scenes' match-all sentinel. Clearing a dashboard-origin (pinned) filter
- * rewrites it to `operator: '=~', value: '.*'` (displayed as "All") and scenes
- * passes it through to the datasource, meaning "this filter restricts nothing"
- * — which is literally how Prometheus evaluates it (anchored matchers, absent
- * labels match `.*`). This plugin has no regex operators (`=~` maps to equals
- * in mapOperator), so forwarding it would invert the intent into
- * `x equals '.*'` — matching nothing. Treat it as no-filter instead (issue #530).
- *
- * Note this also drops a MANUALLY authored `=~ '.*'` — intentional, since the
- * shapes are indistinguishable and the sentinel semantics ("restrict nothing")
- * are what a user typing that would expect anyway. Anyone relying on the
- * temporary =~→equals mapping to match the literal string `.*` must use
- * `= '.*'`, which is untouched.
+ * Scenes' "All" sentinel value. Not exported by any @grafana package, so the
+ * literal is duplicated here (it matches ALL_VARIABLE_VALUE in grafana/scenes).
  */
-export function isMatchAllFilter(filter: Pick<AdHocFilter, 'operator' | 'value'>): boolean {
+const ALL_VALUE = '$__all';
+
+/**
+ * Scenes' match-all filters — a pinned filter that restricts nothing, displayed
+ * as "All". Two shapes exist and both must resolve to no-filter:
+ *
+ * - `=| $__all` — the current shape. Since grafana/scenes#1591 a dashboard-origin
+ *   filter carries the All sentinel on the "one of" operator, whether authored
+ *   that way in the default filters editor or selected by a viewer.
+ * - `=~ .*` — the older shape, still produced for datasources that do not
+ *   declare multi-value operators (issue #530).
+ *
+ * Scenes excludes both from `DataQueryRequest.filters`, but they still reach the
+ * plugin: when that list arrives empty, resolveAdHocFilters falls back to the
+ * dashboard AdHoc variable's raw filters (issue #127), which recovers exactly
+ * what scenes removed. So the drop has to happen here, not upstream.
+ *
+ * Forwarding either shape inverts the intent. This plugin has no regex operators
+ * and mapOperator collapses both `=~` and `=|` to equals, so the pill promises
+ * everything while the query asks for `x equals '.*'` / `x equals '$__all'` —
+ * matching nothing.
+ *
+ * Note this also drops a MANUALLY authored `=~ '.*'`, or `$__all` picked via
+ * "one of" — intentional, since the shapes are indistinguishable and "restrict
+ * nothing" is what a user selecting them would expect anyway. Anyone needing the
+ * literal string must use `= '.*'` / `= '$__all'`, which are untouched.
+ */
+export function isMatchAllFilter(filter: Pick<AdHocFilter, 'operator' | 'value' | 'values'>): boolean {
+  if (filter.operator === ONE_OF_OPERATOR) {
+    return (filter.values ?? (filter.value ? [filter.value] : [])).includes(ALL_VALUE);
+  }
+
   return filter.operator === '=~' && filter.value === '.*';
 }
 
 /** Drop scenes' match-all sentinel filters — see isMatchAllFilter (issue #530). */
-export function dropMatchAllFilters<T extends Pick<AdHocFilter, 'operator' | 'value'>>(filters: T[]): T[] {
+export function dropMatchAllFilters<T extends Pick<AdHocFilter, 'operator' | 'value' | 'values'>>(filters: T[]): T[] {
   return filters.filter((filter) => !isMatchAllFilter(filter));
 }
 
@@ -44,9 +67,9 @@ export function dropMatchAllFilters<T extends Pick<AdHocFilter, 'operator' | 'va
  * variables from `templateSrv.getVariables()` that target this datasource.
  * Fall back to the deprecated `getAdhocFilters(name)` for older Grafana.
  *
- * Match-all sentinels (`=~ .*`) are dropped from the result after resolution,
- * so an explicit list containing only match-all filters still counts as an
- * intentional (now empty) selection and does not fall back to other sources.
+ * Match-all sentinels (`=| $__all` and `=~ .*`) are dropped from the result after
+ * resolution, so an explicit list containing only match-all filters still counts
+ * as an intentional (now empty) selection and does not fall back to other sources.
  */
 export function resolveAdHocFilters(
   datasource: { name: string; uid: string },


### PR DESCRIPTION
Follow-up to #530 / #531 for the sentinel shape scenes now emits.

## Symptom

On a dashboard with five pinned (dashboard-origin) filters set to **All**, every Cube panel returns 0 rows or No data. Captured request body from the live dashboard:

```json
{ "member": "sales_northern_lights.ae_l1_territory",
  "operator": "equals",
  "values": ["$__all"] }
```

Five of those, ANDed. Nothing equals the literal string `$__all`, so the pill promises everything and the query asks for nothing.

## Cause

Since grafana/scenes#1591, a pinned filter that restricts nothing carries the All sentinel on the multi-value operator — `operator: '=|', values: ['$__all']` — instead of the older `=~ .*`. #531 dropped only the regex shape, and `mapOperator` collapses `=|` to equals, so the new shape was forwarded as a literal.

The delivery route is the non-obvious part. Scenes *does* exclude these filters from `DataQueryRequest.filters` (`DrilldownDependenciesManager.getFilters()` skips `isMatchAllFilter`). But that means the explicit list arrives **empty**, and `resolveAdHocFilters` then falls back to reading the dashboard AdHoc variable's raw filters (issue #127) — recovering exactly what scenes had removed. That fallback cannot distinguish "empty because everything is All" from "empty because Grafana didn't pass them", so the drop has to happen in this plugin rather than upstream.

## Change

`isMatchAllFilter` now recognises both shapes, so both entry points already covered by #531 get the new sentinel for free:

- `resolveAdHocFilters` — panel queries and query-editor value lookups
- `getTagValues` scoping filters

Only the one-of operator is treated this way. Scenes never offers All for "not one of" (it would read as excluding everything), so a literal `$__all` on any other operator stays a real filter. `=|` with real values is untouched.

Mixed `['AMER', '$__all']` counts as match-all, mirroring scenes' own `.includes()` — scenes makes All exclusive in the combobox so it should not occur, but diverging would be worse than matching.

## Testing

337 tests pass across 20 suites. Reverting just the source change fails 11 of the new tests, so they are load-bearing.

New coverage:
- `isMatchAllFilter` for both the `values` and value-only shapes; not triggered on `!=|` or `=`
- the regression path specifically: sentinel recovered from the variable fallback when the explicit list is empty
- the reported dashboard case: every pinned filter All → no Cube filters at all
- `getTagValues` no longer scopes on the sentinel
- `=|` with real values still filters

## Note on grafana/scenes#1602

That issue proposes `=| $__all` as the cleared state partly on the grounds that it is "stripped before any datasource sees it - neutral by construction". This PR is evidence that it is not, because of the fallback above. Commented there separately.
